### PR TITLE
feat(seo): SEO optimization for docs site and repo discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Setting up EKS Auto Mode using Terraform
 
+[![License: MIT-0](https://img.shields.io/badge/License-MIT--0-yellow.svg)](https://opensource.org/licenses/MIT-0)
+[![EKS](https://img.shields.io/badge/EKS-Auto%20Mode-FF9900?logo=amazoneks)](https://aws.amazon.com/eks/auto-mode/)
+[![Terraform](https://img.shields.io/badge/Terraform-%3E%3D1.5-844FBA?logo=terraform)](https://www.terraform.io/)
+[![Kubernetes](https://img.shields.io/badge/Kubernetes-1.34-326CE5?logo=kubernetes)](https://kubernetes.io/)
+[![Docs](https://img.shields.io/badge/Docs-GitHub%20Pages-blue)](https://aws-samples.github.io/sample-aws-eks-auto-mode/)
+
+> **Automate Kubernetes the easy way** — deploy once, explore GPU, Spot, Graviton, cost optimization, ODCR, disruption budgets, observability, and more. No add-on management required.
+
 ## Table of Contents
 - [Overview](#overview)
 - [Prerequisites](#prerequisites)

--- a/misc/website/docs/architecture/cleanup.md
+++ b/misc/website/docs/architecture/cleanup.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 2
 title: Cleanup Playbook
+description: "EKS Auto Mode cleanup playbook — safely destroy clusters without orphaning EBS volumes, ALBs, ENIs, and security groups. 14-category post-destroy sweep."
+keywords: [EKS cleanup, destroy EKS cluster, orphaned resources EKS, eks terraform destroy, clean up kubernetes]
 ---
 
 # EKS Auto Mode — Cleanup Playbook

--- a/misc/website/docs/architecture/index.md
+++ b/misc/website/docs/architecture/index.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 5
 title: Architecture
+description: "EKS Auto Mode architecture deep-dives — tagging strategies, cleanup playbooks, and security considerations for production Kubernetes on AWS."
+keywords: [EKS Auto Mode architecture, eks production, kubernetes architecture AWS, EKS best practices]
 ---
 
 # Architecture

--- a/misc/website/docs/architecture/security.md
+++ b/misc/website/docs/architecture/security.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 3
 title: Security Considerations
+description: "EKS Auto Mode security considerations — Checkov scan results, security trade-offs, and hardening guidance for Kubernetes on AWS."
+keywords: [EKS security, eks auto mode security, kubernetes security AWS, Checkov EKS, harden kubernetes]
 ---
 
 # Security Considerations

--- a/misc/website/docs/architecture/tagging.md
+++ b/misc/website/docs/architecture/tagging.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 1
 title: 5-Layer Tagging
+description: "5-layer resource tagging for EKS Auto Mode — tag EC2 instances, EBS volumes, ENIs, ALBs, and security groups created by Kubernetes controllers for full cost allocation."
+keywords: [EKS tagging, eks auto mode tags, kubernetes resource tagging, AWS cost allocation tags, tag EKS nodes]
 ---
 
 # EKS Auto Mode — 5-Layer Tagging

--- a/misc/website/docs/contributing.md
+++ b/misc/website/docs/contributing.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 10
 title: Contributing
+description: "Contribute to EKS Auto Mode Samples — guidelines for adding examples, documentation standards, and pull request workflow."
+keywords: [contribute EKS samples, open source kubernetes, AWS samples contributing]
 ---
 
 # Contributing

--- a/misc/website/docs/examples/batch-jobs.md
+++ b/misc/website/docs/examples/batch-jobs.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 9
 title: "Batch Jobs: Protecting Long-Running Workloads from Disruption"
+description: "Protect batch jobs from disruption on EKS Auto Mode — use do-not-disrupt annotations to prevent Karpenter consolidation during long-running ML training and ETL pipelines."
+keywords: [EKS batch jobs, do-not-disrupt, protect kubernetes jobs, ML training EKS, long-running jobs EKS]
 ---
 
 # Batch Jobs: Protecting Long-Running Workloads from Disruption

--- a/misc/website/docs/examples/capacity-reservation.md
+++ b/misc/website/docs/examples/capacity-reservation.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 7
 title: On-Demand Capacity Reservation (ODCR) Targeting in EKS Auto Mode
+description: "Target On-Demand Capacity Reservations (ODCR) with EKS Auto Mode — guarantee instance availability for critical workloads using NodeClass capacityReservationSelectorTerms."
+keywords: [EKS ODCR, capacity reservation EKS, eks auto mode ODCR, guaranteed capacity kubernetes, reserved instances EKS]
 ---
 
 # On-Demand Capacity Reservation (ODCR) Targeting in EKS Auto Mode

--- a/misc/website/docs/examples/cost-optimization.md
+++ b/misc/website/docs/examples/cost-optimization.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 5
 title: Cost Optimization Patterns for EKS Auto Mode
+description: "EKS Auto Mode cost optimization — OD/Spot mixed scheduling, pause-pod overprovision headroom, and topology spread for cost-efficient Kubernetes clusters."
+keywords: [EKS cost optimization, eks auto mode cost, reduce kubernetes costs, spot on-demand mix, overprovision EKS]
 ---
 
 # Cost Optimization Patterns for EKS Auto Mode

--- a/misc/website/docs/examples/disruption-budgets.md
+++ b/misc/website/docs/examples/disruption-budgets.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 10
 title: Disruption Budgets
+description: "EKS Auto Mode disruption budgets — control node consolidation with time-windowed budgets, business-hours protection, and reason-specific disruption limits."
+keywords: [EKS disruption budgets, nodepool budget, kubernetes node consolidation, business hours protection, EKS availability]
 ---
 
 # Disruption Budgets

--- a/misc/website/docs/examples/gpu.md
+++ b/misc/website/docs/examples/gpu.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 3
 title: GPU Workloads on EKS Auto Mode
+description: "Run GPU workloads on EKS Auto Mode — NVIDIA GPU NodePool configuration, ML inference, and AI/ML training on Kubernetes with p4d, p5, g5, and g6 instances."
+keywords: [EKS GPU, eks auto mode gpu, GPU kubernetes, ML on EKS, NVIDIA EKS, AI kubernetes]
 ---
 
 # GPU Workloads on EKS Auto Mode

--- a/misc/website/docs/examples/graviton.md
+++ b/misc/website/docs/examples/graviton.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 1
 title: Graviton Workloads on EKS Auto Mode
+description: "Run ARM64 Graviton workloads on EKS Auto Mode — NodePool configuration, multi-arch builds, and cost-performance optimization for Kubernetes on AWS Graviton."
+keywords: [EKS Graviton, eks auto mode graviton, ARM64 kubernetes, graviton nodepool, aws graviton eks]
 ---
 
 # Graviton Workloads on EKS Auto Mode

--- a/misc/website/docs/examples/index.md
+++ b/misc/website/docs/examples/index.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 3
 title: Examples
+description: "Deployable EKS Auto Mode examples — GPU, Graviton, Spot, cost optimization, ODCR capacity reservations, disruption budgets, batch jobs, and observability patterns."
+keywords: [EKS Auto Mode examples, eks automode patterns, kubernetes examples, EKS terraform examples, automate EKS workloads]
 ---
 
 # Examples

--- a/misc/website/docs/examples/neuron.md
+++ b/misc/website/docs/examples/neuron.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 4
 title: Neuron Workloads on EKS Auto Mode
+description: "Run AWS Inferentia and Trainium workloads on EKS Auto Mode — Neuron NodePool configuration for ML inference and training with inf2 and trn1 instances."
+keywords: [EKS Neuron, eks auto mode inferentia, trainium kubernetes, AWS Inferentia EKS, ML inference EKS]
 ---
 
 # Neuron Workloads on EKS Auto Mode

--- a/misc/website/docs/examples/observability.md
+++ b/misc/website/docs/examples/observability.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 12
 title: Observability with CloudWatch Container Insights
+description: "EKS Auto Mode observability with CloudWatch Container Insights — monitor Kubernetes clusters, nodes, and pods without managing monitoring infrastructure."
+keywords: [EKS observability, CloudWatch Container Insights, monitor EKS, kubernetes monitoring, eks auto mode metrics]
 ---
 
 # Observability with CloudWatch Container Insights

--- a/misc/website/docs/examples/pod-autoscaling.md
+++ b/misc/website/docs/examples/pod-autoscaling.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 11
 title: Pod Autoscaling on EKS Auto Mode
+description: "Pod autoscaling on EKS Auto Mode — configure HPA and KEDA for automatic workload scaling with Kubernetes metrics and event-driven triggers."
+keywords: [EKS autoscaling, HPA EKS, KEDA kubernetes, pod autoscaling, scale kubernetes workloads, eks auto mode scaling]
 ---
 
 # Pod Autoscaling on EKS Auto Mode

--- a/misc/website/docs/examples/spot.md
+++ b/misc/website/docs/examples/spot.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 2
 title: Spot Workloads on EKS Auto Mode
+description: "Run Spot instances on EKS Auto Mode — configure NodePools for Spot capacity, handle interruptions gracefully, and reduce Kubernetes compute costs by up to 90%."
+keywords: [EKS Spot instances, eks auto mode spot, spot kubernetes, reduce EKS costs, spot nodepool]
 ---
 
 # Spot Workloads on EKS Auto Mode

--- a/misc/website/docs/examples/static-capacity.md
+++ b/misc/website/docs/examples/static-capacity.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 8
 title: Static Capacity Pools
+description: "Static capacity pools in EKS Auto Mode — maintain fixed node counts with NodePool replicas for always-on workloads that need guaranteed compute."
+keywords: [EKS static capacity, nodepool replicas, fixed nodes kubernetes, always-on EKS, guaranteed compute EKS]
 ---
 
 # Static Capacity Pools

--- a/misc/website/docs/getting-started.md
+++ b/misc/website/docs/getting-started.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 2
 title: Getting Started
+description: "Get started with EKS Auto Mode — deploy an automated Kubernetes cluster in minutes using Terraform. Step-by-step setup guide for AWS EKS Auto Mode."
+keywords: [EKS Auto Mode setup, eks auto mode terraform, getting started EKS, deploy EKS cluster, kubernetes quickstart]
 ---
 
 # Getting Started

--- a/misc/website/docs/intro.md
+++ b/misc/website/docs/intro.md
@@ -1,6 +1,8 @@
 ---
 sidebar_position: 1
 title: Introduction
+description: "Introduction to EKS Auto Mode Samples — learn how to automate Kubernetes compute, storage, and networking with deployable Terraform examples. Simplify EKS operations without managing add-ons."
+keywords: [EKS Auto Mode, eks automode, automate kubernetes, simplify EKS, terraform examples, managed kubernetes]
 ---
 
 # EKS Auto Mode Samples

--- a/misc/website/docusaurus.config.ts
+++ b/misc/website/docusaurus.config.ts
@@ -24,6 +24,52 @@ const config: Config = {
     locales: ['en'],
   },
 
+  headTags: [
+    {
+      tagName: 'meta',
+      attributes: {name: 'keywords', content: 'EKS Auto Mode, eks automode, Amazon EKS Auto Mode, automate EKS, automate kubernetes, simplify kubernetes, managed kubernetes, kubernetes automation, EKS terraform, EKS examples, EKS tutorial, EKS cost optimization, EKS GPU, EKS Spot, EKS Graviton, Karpenter, NodePool, NodeClass'},
+    },
+    {
+      tagName: 'meta',
+      attributes: {property: 'og:type', content: 'website'},
+    },
+    {
+      tagName: 'meta',
+      attributes: {property: 'og:image', content: 'https://aws-samples.github.io/sample-aws-eks-auto-mode/img/og-card.png'},
+    },
+    {
+      tagName: 'meta',
+      attributes: {property: 'og:site_name', content: 'EKS Auto Mode Samples'},
+    },
+    {
+      tagName: 'meta',
+      attributes: {name: 'twitter:card', content: 'summary_large_image'},
+    },
+    {
+      tagName: 'meta',
+      attributes: {name: 'twitter:image', content: 'https://aws-samples.github.io/sample-aws-eks-auto-mode/img/og-card.png'},
+    },
+    {
+      tagName: 'script',
+      attributes: {type: 'application/ld+json'},
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'SoftwareSourceCode',
+        name: 'EKS Auto Mode Samples',
+        description: 'Learn Amazon EKS Auto Mode through deployable Terraform examples. Automate Kubernetes compute, storage, and networking with GPU, Spot, Graviton, and cost optimization patterns.',
+        url: 'https://aws-samples.github.io/sample-aws-eks-auto-mode/',
+        codeRepository: 'https://github.com/aws-samples/sample-aws-eks-auto-mode',
+        programmingLanguage: ['HCL', 'YAML', 'Bash'],
+        runtimePlatform: 'Amazon EKS',
+        license: 'https://opensource.org/licenses/MIT-0',
+        author: {
+          '@type': 'Organization',
+          name: 'AWS Solutions Architects',
+        },
+      }),
+    },
+  ],
+
   presets: [
     [
       'classic',
@@ -41,6 +87,10 @@ const config: Config = {
   ],
 
   themeConfig: {
+    metadata: [
+      {name: 'description', content: 'Learn Amazon EKS Auto Mode through deployable Terraform examples. Automate Kubernetes compute, storage, and networking — GPU, Spot, Graviton, cost optimization, and observability patterns.'},
+      {name: 'og:description', content: 'Deployable Terraform examples for EKS Auto Mode — automate Kubernetes the easy way. GPU, Spot, Graviton, ODCR, disruption budgets, and more.'},
+    ],
     navbar: {
       title: 'EKS Auto Mode Samples',
       items: [

--- a/misc/website/package.json
+++ b/misc/website/package.json
@@ -2,6 +2,14 @@
   "name": "sample-aws-eks-auto-mode-website",
   "version": "0.0.0",
   "private": true,
+  "description": "Documentation site for EKS Auto Mode Samples — learn Amazon EKS Auto Mode through deployable Terraform examples for GPU, Spot, Graviton, cost optimization, and Kubernetes automation",
+  "keywords": ["eks", "eks-auto-mode", "automode", "kubernetes", "terraform", "aws", "karpenter", "gpu", "spot", "graviton", "cost-optimization", "nodepool", "nodeclass"],
+  "homepage": "https://aws-samples.github.io/sample-aws-eks-auto-mode/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws-samples/sample-aws-eks-auto-mode.git",
+    "directory": "misc/website"
+  },
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",

--- a/misc/website/src/pages/index.tsx
+++ b/misc/website/src/pages/index.tsx
@@ -13,6 +13,9 @@ function Hero() {
           <br />
           Deploy once, explore everything.
         </p>
+        <p className="landing-hero__seo-description" style={{fontSize: '1rem', opacity: 0.85, maxWidth: '600px', margin: '0 auto 1.5rem'}}>
+          Automate Kubernetes compute, storage, and networking on AWS. Production-ready patterns for GPU, Spot, Graviton, cost optimization, capacity reservations, and more — no add-on management required.
+        </p>
         <div className="landing-hero__actions">
           <Link className="landing-hero__btn landing-hero__btn--primary" to="/docs/getting-started">
             Get Started

--- a/misc/website/static/img/og-card.svg
+++ b/misc/website/static/img/og-card.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <rect width="1200" height="630" fill="#232F3E"/>
+  <text x="600" y="260" font-family="system-ui, -apple-system, sans-serif" font-size="72" font-weight="bold" fill="#FFFFFF" text-anchor="middle">EKS Auto Mode</text>
+  <text x="600" y="340" font-family="system-ui, -apple-system, sans-serif" font-size="36" fill="#FF9900" text-anchor="middle">Deployable Terraform Examples</text>
+  <text x="600" y="540" font-family="system-ui, -apple-system, sans-serif" font-size="24" fill="#8899AA" text-anchor="middle">aws-samples</text>
+</svg>

--- a/misc/website/static/robots.txt
+++ b/misc/website/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://aws-samples.github.io/sample-aws-eks-auto-mode/sitemap.xml


### PR DESCRIPTION
## Summary
- Add global meta tags (OG, Twitter card, keywords), JSON-LD structured data, and `robots.txt` to Docusaurus site
- Add unique `description` + `keywords` frontmatter to all 19 doc pages
- Add OG social card SVG image
- Add README badges (License, EKS, Terraform, K8s, Docs) and keyword-rich tagline
- Add SEO subtitle to homepage hero component
- Set 15 GitHub repository topics for discoverability
- Fill `package.json` SEO fields (description, keywords, homepage, repository)

## Keyword strategy
Targets all variations: "EKS Auto Mode", "eks automode", "automate EKS", "simplify kubernetes", "kubernetes automation" — plus per-page long-tail terms (gpu, spot, graviton, cost optimization, ODCR, etc.)

## Test plan
- [x] `npm run build` passes (no new errors)
- [ ] GitHub Pages deploys successfully after merge
- [ ] Social card preview renders on Slack/Twitter link paste
- [ ] Google Search Console picks up new meta descriptions