### PR TITLE
fix(seo): remove em-dash from intro page description

### DIFF
--- a/misc/website/docs/intro.md
+++ b/misc/website/docs/intro.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 title: Introduction
-description: "Introduction to EKS Auto Mode Samples — learn how to automate Kubernetes compute, storage, and networking with deployable Terraform examples. Simplify EKS operations without managing add-ons."
+description: "Introduction to EKS Auto Mode Samples. Learn how to automate Kubernetes compute, storage, and networking with deployable Terraform examples. Simplify EKS operations without managing add-ons."
 keywords: [EKS Auto Mode, eks automode, automate kubernetes, simplify EKS, terraform examples, managed kubernetes]
 ---
 


### PR DESCRIPTION
## Summary
- Replace em-dash with period in intro page meta description for cleaner display in search results

## Test plan
- [x] Site builds cleanly