### PR TITLE
fix(seo): remove em-dashes from landing page

### DIFF
--- a/misc/website/docs/intro.md
+++ b/misc/website/docs/intro.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 title: Introduction
-description: "Introduction to EKS Auto Mode Samples — learn how to automate Kubernetes compute, storage, and networking with deployable Terraform examples. Simplify EKS operations without managing add-ons."
+description: "Introduction to EKS Auto Mode Samples. Learn how to automate Kubernetes compute, storage, and networking with deployable Terraform examples. Simplify EKS operations without managing add-ons."
 keywords: [EKS Auto Mode, eks automode, automate kubernetes, simplify EKS, terraform examples, managed kubernetes]
 ---
 

--- a/misc/website/docusaurus.config.ts
+++ b/misc/website/docusaurus.config.ts
@@ -88,8 +88,8 @@ const config: Config = {
 
   themeConfig: {
     metadata: [
-      {name: 'description', content: 'Learn Amazon EKS Auto Mode through deployable Terraform examples. Automate Kubernetes compute, storage, and networking — GPU, Spot, Graviton, cost optimization, and observability patterns.'},
-      {name: 'og:description', content: 'Deployable Terraform examples for EKS Auto Mode — automate Kubernetes the easy way. GPU, Spot, Graviton, ODCR, disruption budgets, and more.'},
+      {name: 'description', content: 'Learn Amazon EKS Auto Mode through deployable Terraform examples. Automate Kubernetes compute, storage, and networking. GPU, Spot, Graviton, cost optimization, and observability patterns.'},
+      {name: 'og:description', content: 'Deployable Terraform examples for EKS Auto Mode. Automate Kubernetes the easy way. GPU, Spot, Graviton, ODCR, disruption budgets, and more.'},
     ],
     navbar: {
       title: 'EKS Auto Mode Samples',

--- a/misc/website/src/pages/index.tsx
+++ b/misc/website/src/pages/index.tsx
@@ -14,7 +14,7 @@ function Hero() {
           Deploy once, explore everything.
         </p>
         <p className="landing-hero__seo-description" style={{fontSize: '1rem', opacity: 0.85, maxWidth: '600px', margin: '0 auto 1.5rem'}}>
-          Automate Kubernetes compute, storage, and networking on AWS. Production-ready patterns for GPU, Spot, Graviton, cost optimization, capacity reservations, and more — no add-on management required.
+          Automate Kubernetes compute, storage, and networking on AWS. Production-ready patterns for GPU, Spot, Graviton, cost optimization, capacity reservations, and more. No add-on management required.
         </p>
         <div className="landing-hero__actions">
           <Link className="landing-hero__btn landing-hero__btn--primary" to="/docs/getting-started">
@@ -32,7 +32,7 @@ function Hero() {
 const features = [
   {
     title: 'Compute Patterns',
-    description: 'Graviton, GPU, Spot, and Neuron — each with a self-contained example explaining the "why" alongside the "how."',
+    description: 'Graviton, GPU, Spot, and Neuron. Each with a self-contained example explaining the "why" alongside the "how."',
   },
   {
     title: 'Cost Optimization',


### PR DESCRIPTION
## Summary
- Replace em-dashes with periods in landing page hero text, site meta description, and OG description for cleaner display

## Test plan
- [x] Site builds cleanly