### PR TITLE
feat(skills): add EKS Auto Mode onboard and maintain skills

### DIFF
--- a/skills/eks-automode-maintain/SKILL.md
+++ b/skills/eks-automode-maintain/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: eks-automode-maintain
+description: >
+  Repo maintenance for sample-aws-eks-auto-mode — keeping docs, templates,
+  rendered YAML, and tagging layers in sync. Use this skill when updating
+  nodepool templates, terraform config, examples, tagging, cleanup scripts,
+  or any docs in this repo. Triggers on: maintain, docs sync, tagging update,
+  template change, rendered yaml, file relationships, PR checklist, keep in sync.
+---
+
+# EKS Auto Mode — Maintainer Skill
+
+You maintain `sample-aws-eks-auto-mode`. This skill tells you what else to
+update when you change a file, how the rendering chain works, and how to verify
+the 5-layer tagging pattern stays consistent.
+
+For the full file map, tagging deep-dive, or docs-sync rules, see `references/`.
+
+---
+
+## The rendering chain
+
+NodePool and example YAML in this repo are template-rendered, not hand-written.
+Understanding this chain prevents the most common maintainer mistake: editing a
+`.tpl` without re-rendering.
+
+```
+nodepool-templates/*.yaml.tpl        (source of truth)
+         │
+         ▼
+terraform/setup.tf                   (templatefile() calls with variables)
+         │
+         ▼
+nodepools/*.yaml                     (rendered output, gitignored)
+examples/*/rendered.yaml             (some example YAMLs are also rendered)
+```
+
+**Variable flow:**
+
+1. `terraform/variables.tf` defines `var.tags`, `var.name`, `var.base_domain`, etc.
+2. `terraform/main.tf` merges into `local.tags` and `local.full_domain`.
+3. `terraform/setup.tf` passes `local.tags`, `module.eks.cluster_name`, `module.eks.node_iam_role_name`, and `var.ephemeral_storage_kms_key_id` into each `templatefile()` call.
+4. `local_file` resources write the rendered YAML to `nodepools/` or `examples/*/`.
+
+**The gotcha:** Editing a `.tpl` file fixes the template but the cluster still
+runs the previously-rendered YAML. You must run `terraform apply` to re-render.
+Running `kubectl apply -f nodepools/` on stale rendered YAML silently reverts
+your fix.
+
+---
+
+## Decision matrix: I changed X, what else needs updating?
+
+| Changed | Also update |
+|---------|-------------|
+| `nodepool-templates/*.yaml.tpl` | Run `terraform apply` to re-render; verify rendered output in `nodepools/` |
+| `terraform/variables.tf` (new var) | `setup.tf` (pass to `templatefile`); README variable reference table |
+| `terraform/eks.tf` | `claude-md/TAGGING.md` if tag-related; README if feature-facing |
+| `examples/*` (new example dir) | README examples table; `misc/website` sidebar; `setup.tf` if `.tpl` needed |
+| `terraform/tagging.tf` | `claude-md/TAGGING.md` (keep in sync); verify all 5 layers still covered |
+| `scripts/cleanup.sh` | `claude-md/CLEANUP.md` flags/usage section |
+| Any observability change | `examples/observability/README.md`; `terraform/observability.tf` |
+| `terraform/versions.tf` | README prerequisites section (provider version badges) |
+| `terraform/ingressclass.tf` | `claude-md/TAGGING.md` Layer 5 section |
+| `terraform/alb-acm.tf` | README domain/DNS section; example Ingress `.tpl` files if host changes |
+| `terraform/setup.tf` (new `local_file`) | `.gitignore` (add rendered output path); README if user-facing |
+
+---
+
+## 5-layer tagging consistency
+
+Every resource the cluster creates should carry your tags. The 5 layers are:
+
+| # | Layer | File | What it tags |
+|---|-------|------|--------------|
+| 1 | Provider `default_tags` | `terraform/main.tf` | All TF-direct resources (VPC, subnets, IAM, KMS, etc.) |
+| 2 | `cluster_tags` | `terraform/eks.tf` | EKS primary security group (unreachable by `default_tags`) |
+| 3 | NodeClass `spec.tags` | `nodepool-templates/*.yaml.tpl` | EC2 instances, root EBS, ENIs from Auto Mode |
+| 4 | StorageClass `tagSpecification` | `terraform/tagging.tf` | PVC-provisioned EBS volumes |
+| 5 | IngressClassParams `spec.tags` | `terraform/ingressclass.tf` | ALBs, target groups, listeners |
+
+**Verification checklist (run after any tag change):**
+
+```bash
+# Layer 1: provider default_tags
+grep -A5 'default_tags' terraform/main.tf
+
+# Layer 2: cluster_tags passed to module
+grep 'cluster_tags' terraform/eks.tf
+
+# Layer 3: spec.tags in every .tpl
+grep -l 'spec.tags' nodepool-templates/*.yaml.tpl | wc -l  # should match template count
+
+# Layer 4: tagSpecification in StorageClass
+grep 'tagSpecification' terraform/tagging.tf
+
+# Layer 5: spec.tags in IngressClassParams
+grep -A2 'spec:' terraform/ingressclass.tf | grep 'tags'
+```
+
+**Confirm tags are actually landing on AWS resources:**
+
+```bash
+# EC2 instances (Layer 3)
+aws ec2 describe-instances --filters "Name=tag:aws:eks:cluster-name,Values=$CLUSTER" \
+  --query 'Reservations[].Instances[].Tags'
+
+# EBS volumes (Layer 4)
+aws ec2 describe-volumes --filters "Name=tag:kubernetes.io/cluster/$CLUSTER,Values=owned" \
+  --query 'Volumes[].Tags'
+
+# ALBs (Layer 5)
+aws elbv2 describe-tags --resource-arns $(aws elbv2 describe-load-balancers \
+  --query 'LoadBalancers[].LoadBalancerArn' --output text)
+```
+
+**IAM requirement:** Layers 3-5 fail silently without `enable_auto_mode_custom_tags = true`
+on the EKS module (default since v20.31). Check `terraform/eks.tf`.
+
+---
+
+## When to update TAGGING.md vs CLEANUP.md
+
+| Update `claude-md/TAGGING.md` when... | Update `claude-md/CLEANUP.md` when... |
+|----------------------------------------|----------------------------------------|
+| Adding/removing a tagging layer | Adding a new resource type that might orphan |
+| Changing tag keys or values | Changing `scripts/cleanup.sh` flags |
+| Updating IAM policy for tags | Discovering a new cleanup ordering dependency |
+| Fixing a "tag not landing" debug path | Adding a verification command |
+| Documenting a new `default_tags` gap | Updating the drain-before-destroy order |
+
+Both files are gitignored (`claude-md/` in `.gitignore`) because they are
+maintainer-internal docs generated for Claude context. They do not ship to
+end-users but they keep institutional knowledge alive across sessions.
+
+---
+
+## PR checklist for maintainers
+
+Before merging, verify:
+
+- [ ] Every `.tpl` change has a matching `terraform apply` validation (CI or local)
+- [ ] New variables appear in README's Configuration section
+- [ ] Tag-related changes are reflected in `claude-md/TAGGING.md`
+- [ ] Cleanup-related changes are reflected in `claude-md/CLEANUP.md`
+- [ ] New examples have their own `README.md` with prerequisites and commands
+- [ ] Rendered YAML paths added to `.gitignore` if generated by `setup.tf`
+- [ ] `SECURITY_CONSIDERATIONS.md` updated if security posture changed
+- [ ] No hardcoded cluster names or account IDs in committed files
+- [ ] Example READMEs use relative paths (no absolute filesystem paths)
+- [ ] Observe commands separated into `examples/observability/` not inline
+
+---
+
+## When to reference the detailed docs
+
+| You need... | Go to... |
+|-------------|----------|
+| Complete file map and dependency graph | `references/file-relationships.md` |
+| Full 5-layer tagging with debug commands | `references/tagging-consistency.md` |
+| Docs update rules and PR template | `references/docs-sync-checklist.md` |
+| Upstream AWS docs on Auto Mode | Links in Sources below |
+
+---
+
+## Sources
+
+- [EKS Auto Mode user guide](https://docs.aws.amazon.com/eks/latest/userguide/automode.html)
+- [Auto Mode IAM roles](https://docs.aws.amazon.com/eks/latest/userguide/auto-learn-iam.html)
+- [Custom NodeClass creation](https://docs.aws.amazon.com/eks/latest/userguide/create-node-class.html)
+- [Tag propagation IAM policy](https://docs.aws.amazon.com/eks/latest/userguide/auto-cluster-iam-role.html#tag-prop)
+- [EKS Auto Mode best practices](https://docs.aws.amazon.com/eks/latest/best-practices/automode.html)
+- [This repo (sample-aws-eks-auto-mode)](https://github.com/aws-samples/sample-aws-eks-auto-mode)
+- [Skill format reference](https://github.com/anthropics/skills/tree/main/skills/skill-creator)
+- Internal: `claude-md/TAGGING.md`, `claude-md/CLEANUP.md`, `terraform/setup.tf`, `nodepool-templates/*.yaml.tpl`

--- a/skills/eks-automode-maintain/references/docs-sync-checklist.md
+++ b/skills/eks-automode-maintain/references/docs-sync-checklist.md
@@ -1,0 +1,180 @@
+# Docs Sync Checklist
+
+Rules for keeping documentation in sync with code changes in this repo.
+
+---
+
+## When to update README.md
+
+Update the root README when:
+
+- A new input variable is added to `variables.tf` — add to the Configuration table
+- A new example directory is created — add to the Examples table with one-line description
+- Provider version constraints change in `versions.tf` — update Prerequisites badges
+- A new prerequisite tool is required — add to Prerequisites list
+- The quick-start flow changes (new steps, different ordering)
+- A new output is added to `outputs.tf` that users need to know about
+- The `base_domain` / DNS behavior changes — update the domain section
+
+Do NOT update README for:
+- Internal refactoring that doesn't change user-facing behavior
+- Changes to `claude-md/` docs (these are gitignored, not user-facing)
+- CI/CD pipeline changes (document in CONTRIBUTING.md instead)
+
+---
+
+## When to update claude-md/TAGGING.md
+
+Update when:
+
+- Adding or removing a tagging layer
+- Changing the IAM policy approach for custom tags
+- Discovering a new resource type that `default_tags` cannot reach
+- Fixing a tag-not-landing issue (add to debugging section)
+- Changing tag key names or default values in `variables.tf`
+- Modifying `terraform/tagging.tf`, `terraform/ingressclass.tf`, or the
+  `spec.tags` block in any `.tpl` file
+- The EKS module version changes and affects tag propagation behavior
+
+Keep in sync with: `terraform/tagging.tf`, `terraform/ingressclass.tf`,
+`terraform/eks.tf` (cluster_tags), `terraform/main.tf` (default_tags),
+`nodepool-templates/*.yaml.tpl` (spec.tags).
+
+---
+
+## When to update claude-md/CLEANUP.md
+
+Update when:
+
+- `scripts/cleanup.sh` gains new flags or changes existing flag behavior
+- A new resource type is discovered that can orphan on cluster deletion
+- The drain-before-destroy ordering changes
+- A new verification command is needed post-cleanup
+- A new Auto Mode gotcha affects cleanup (e.g., new managed resources)
+- The post-destroy orphan checklist needs a new entry
+
+Keep in sync with: `scripts/cleanup.sh` (flags, usage, ordering).
+
+---
+
+## When to update SECURITY_CONSIDERATIONS.md
+
+Update when:
+
+- IAM role scope changes (more permissive or more restrictive)
+- Network exposure changes (new public endpoints, security group rules)
+- Encryption settings change (KMS key usage, at-rest/in-transit)
+- A new Pod Identity association is added
+- The external-dns IAM scoping changes
+- Default security posture changes (e.g., `enable_domain` default)
+
+---
+
+## Docusaurus site sync (misc/website/)
+
+The GitHub Pages site at `misc/website/` mirrors content from example READMEs.
+
+When adding a new example:
+1. Create the example's `README.md` first.
+2. Add a sidebar entry in the Docusaurus config.
+3. Verify the page renders correctly with `npm run build` in `misc/website/`.
+
+The site does not auto-sync — manual rebuild and deploy is required.
+
+---
+
+## Example README standards
+
+Every example directory under `examples/` should have a `README.md` that follows:
+
+**Structure:**
+1. Title (H1) — what this example demonstrates
+2. Overview — 2-3 sentences explaining the pattern and why you'd use it
+3. Prerequisites — what must be deployed first (link to root README Quick Start)
+4. Deploy — step-by-step `kubectl apply` commands
+5. Verify — commands to confirm the example is working
+6. Observe (if applicable) — point to `examples/observability/`, do not inline
+7. Clean up — how to remove just this example's resources
+
+**Rules:**
+- Use relative paths to reference other files in the repo (e.g., `../../nodepools/`)
+- Keep observe/monitoring commands in `examples/observability/README.md`, not inline
+- No `terraform` commands outside the root quick-start or `examples/observability/`
+- Prerequisites should reference the base cluster deployment, not repeat it
+- Include the rendered YAML filename if the example has a `.tpl` (remind users to
+  run terraform first)
+
+---
+
+## PR description template
+
+Use this structure for PRs to this repo:
+
+```markdown
+## What
+
+Brief description of the change (1-2 sentences).
+
+## Why
+
+Context on why this change is needed.
+
+## What else was updated
+
+- [ ] README.md (if user-facing change)
+- [ ] claude-md/TAGGING.md (if tag-related)
+- [ ] claude-md/CLEANUP.md (if cleanup-related)
+- [ ] SECURITY_CONSIDERATIONS.md (if security-related)
+- [ ] .gitignore (if new rendered output)
+- [ ] Example READMEs (if example behavior changed)
+
+## Testing
+
+How this was validated (terraform plan output, kubectl apply, etc.)
+```
+
+---
+
+## Cross-reference: which docs cover which code
+
+| Code file | Primary doc | Secondary doc |
+|-----------|-------------|---------------|
+| `terraform/main.tf` | README (Prerequisites) | TAGGING.md (Layer 1) |
+| `terraform/eks.tf` | README (Components) | TAGGING.md (Layer 2) |
+| `terraform/variables.tf` | README (Configuration) | — |
+| `terraform/setup.tf` | — (internal plumbing) | file-relationships.md |
+| `terraform/tagging.tf` | TAGGING.md (Layer 4) | README (5-layer mention) |
+| `terraform/ingressclass.tf` | TAGGING.md (Layer 5) | — |
+| `terraform/alb-acm.tf` | README (Domain/DNS section) | SECURITY_CONSIDERATIONS.md |
+| `terraform/observability.tf` | examples/observability/README.md | README (feature list) |
+| `nodepool-templates/*.yaml.tpl` | TAGGING.md (Layer 3) | README (architecture) |
+| `scripts/cleanup.sh` | CLEANUP.md | README (Cleanup section) |
+| `examples/*/` | Each example's own README.md | Root README examples table |
+
+---
+
+## Staleness signals
+
+Watch for these signs that docs are out of sync:
+
+- README mentions a variable that no longer exists in `variables.tf`
+- TAGGING.md references a file path that has moved
+- CLEANUP.md flags don't match `scripts/cleanup.sh --help` output
+- Example README references a YAML file that is now template-rendered
+- Version badges in README don't match `versions.tf` constraints
+- The examples table in README is missing a directory that exists in `examples/`
+
+Run this quick check:
+```bash
+# Examples in filesystem vs README
+diff <(ls examples/ | sort) <(grep -oP '(?<=examples/)\w+' README.md | sort -u)
+```
+
+---
+
+## Sources
+
+- [This repo (sample-aws-eks-auto-mode)](https://github.com/aws-samples/sample-aws-eks-auto-mode)
+- [EKS Auto Mode user guide](https://docs.aws.amazon.com/eks/latest/userguide/automode.html)
+- [Skill format reference](https://github.com/anthropics/skills/tree/main/skills/skill-creator)
+- Internal: `claude-md/TAGGING.md`, `claude-md/CLEANUP.md`, `README.md`, `SECURITY_CONSIDERATIONS.md`

--- a/skills/eks-automode-maintain/references/file-relationships.md
+++ b/skills/eks-automode-maintain/references/file-relationships.md
@@ -1,0 +1,163 @@
+# File Relationships and Dependency Graph
+
+Complete map of `sample-aws-eks-auto-mode` with dependency flows for maintainers.
+
+---
+
+## Directory overview
+
+```
+sample-aws-eks-auto-mode/
+├── terraform/              Core infrastructure (single apply creates everything)
+├── nodepool-templates/     Template sources for NodePool/NodeClass YAML
+├── nodepools/              Rendered output (gitignored) — never edit directly
+├── examples/               11 self-contained example directories
+├── scripts/                Operational scripts (cleanup, helpers)
+├── claude-md/              Maintainer docs (TAGGING.md, CLEANUP.md) — gitignored
+├── misc/website/           Docusaurus site for GitHub Pages
+├── skills/                 Claude skills for this repo
+├── README.md               User-facing entry point
+├── SECURITY_CONSIDERATIONS.md  Security posture documentation
+├── CONTRIBUTING.md         Contribution guidelines
+└── .gitignore              Includes nodepools/, rendered example YAMLs, claude-md/
+```
+
+---
+
+## terraform/ — file-by-file
+
+| File | Purpose | Depends on | Depended on by |
+|------|---------|------------|----------------|
+| `main.tf` | AWS + helm + kubectl providers; `local.tags`, `local.azs`, `local.enable_domain`, `local.full_domain` | `variables.tf` | Everything (providers + locals) |
+| `variables.tf` | All input variables (`name`, `region`, `tags`, `base_domain`, etc.) | — | `main.tf`, `eks.tf`, `setup.tf`, `vpc.tf`, `alb-acm.tf` |
+| `versions.tf` | Provider version constraints (aws >=5.79, helm ~>2.17, kubectl ~>2.1) | — | `main.tf` (implicit) |
+| `vpc.tf` | VPC module (3 AZ, public/private subnets, NAT, karpenter discovery tags) | `main.tf` locals | `eks.tf` (vpc_id, subnet_ids) |
+| `eks.tf` | EKS cluster module; enables Auto Mode, custom tag IAM, cluster_tags | `vpc.tf`, `main.tf` | `setup.tf`, `tagging.tf`, `ingressclass.tf`, `observability.tf`, `alb-acm.tf`, `outputs.tf` |
+| `setup.tf` | `templatefile()` rendering chain; `local_file` resources for all `.tpl` files | `eks.tf` (outputs), `main.tf` (locals), `.tpl` files | `nodepools/`, rendered example YAMLs |
+| `tagging.tf` | Layer 4 StorageClass with `tagSpecification`; deletes legacy gp2 | `eks.tf`, `main.tf` (local.tags) | PVC-created EBS volumes |
+| `ingressclass.tf` | Layer 5 IngressClassParams + IngressClass (internal or internet-facing) | `eks.tf`, `main.tf`, `alb-acm.tf` (if domain enabled) | ALB/TG tagging |
+| `alb-acm.tf` | Route53 zone lookup, ACM wildcard cert, external-dns Helm + IAM | `eks.tf`, `main.tf` | `ingressclass.tf` (ACM validation dep) |
+| `observability.tf` | CloudWatch Container Insights addon + IAM attachment | `eks.tf` | — |
+| `outputs.tf` | Exports: configure_kubectl command, cluster_name, oidc_provider_arn, region | `eks.tf`, `variables.tf` | Users, CI |
+
+---
+
+## nodepool-templates/ — template sources
+
+| File | Renders to | NodeClass name | Instance families |
+|------|-----------|----------------|-------------------|
+| `gpu-nodepool.yaml.tpl` | `nodepools/gpu-nodepool.yaml` | `gpu-nodeclass` | g5, g6, g6e, p5, p5e |
+| `graviton-nodepool.yaml.tpl` | `nodepools/graviton-nodepool.yaml` | `graviton-nodeclass` | (ARM64 instances) |
+| `neuron-nodepool.yaml.tpl` | `nodepools/neuron-nodepool.yaml` | `neuron-nodeclass` | inf2, trn1 |
+| `spot-nodepool.yaml.tpl` | `nodepools/spot-nodepool.yaml` | `spot-nodeclass` | (Spot capacity) |
+
+Each template receives these variables from `setup.tf`:
+- `node_iam_role_name` — from `module.eks.node_iam_role_name`
+- `cluster_name` — from `module.eks.cluster_name`
+- `tags` — from `local.tags` (map)
+- `kms_key_id` — from `var.ephemeral_storage_kms_key_id`
+
+Every template includes `spec.tags: ${indent(4, yamlencode(tags))}` for Layer 3
+tagging. If you add a new template, follow this pattern.
+
+---
+
+## The templatefile() rendering chain in detail
+
+```
+variables.tf          main.tf              setup.tf              .tpl file           Output
+┌──────────┐     ┌──────────────┐     ┌──────────────────┐     ┌───────────┐     ┌───────────┐
+│ var.tags │────►│ local.tags   │────►│ templatefile(    │────►│ ${tags}   │────►│ nodepools/│
+│ var.name │     │  = merge(    │     │   "...tpl",      │     │ ${cluster}│     │ *.yaml    │
+│          │     │    var.tags, │     │   { tags=...     │     │           │     │           │
+│          │     │    Blueprint)│     │     cluster=...})│     │           │     │           │
+└──────────┘     └──────────────┘     └──────────────────┘     └───────────┘     └───────────┘
+                                              │
+                                              ▼
+                                      local_file resource
+                                      (writes to disk)
+```
+
+**Adding a new template:**
+1. Create `nodepool-templates/my-nodepool.yaml.tpl` with the standard variable placeholders.
+2. Add a `resource "local_file" "setup_my_nodepool"` block in `setup.tf`.
+3. Add the output path to `.gitignore`.
+4. Run `terraform apply` to validate rendering.
+5. Update README if user-facing.
+
+---
+
+## examples/ — how they relate to templates
+
+| Directory | Has `.tpl`? | Rendered by `setup.tf`? | Purpose |
+|-----------|-------------|-------------------------|---------|
+| `batch-jobs/` | No | No | Job scheduling patterns |
+| `capacity-reservation/` | Yes (`odcr-nodepool.yaml.tpl`) | Yes | ODCR targeting |
+| `cost-optimization/` | No | No | Overprovision, consolidation |
+| `disruption-budgets/` | No | No | NodePool disruption budget configs |
+| `gpu/` | Yes (`lb-service.yaml.tpl`) | Yes | GPU inference with LB exposure |
+| `graviton/` | Yes (`2048-ingress.yaml.tpl`) | Yes | ARM64 workload with Ingress |
+| `neuron/` | Yes (`vllm-deployment.yaml.tpl`) | Yes | Inferentia2 vLLM |
+| `observability/` | No | No | CloudWatch Container Insights |
+| `pod-autoscaling/` | Yes (KEDA templates) | Yes (keda.tf) | HPA + KEDA scaling |
+| `spot/` | Yes (`2048-ingress.yaml.tpl`) | Yes | Spot capacity with Ingress |
+| `static-capacity/` | Yes (`static-nodepool.yaml.tpl`) | Yes | Fixed-size node pools |
+
+Examples with `.tpl` files depend on `terraform apply` to produce usable YAML.
+The rendered outputs are gitignored so users must run terraform before `kubectl apply`.
+
+---
+
+## scripts/
+
+| File | Purpose |
+|------|---------|
+| `cleanup.sh` | Full cluster teardown: drain k8s resources, terraform destroy, orphan sweep |
+
+The cleanup script implements the drain-before-destroy order documented in
+`claude-md/CLEANUP.md`. Changes to the script should always be mirrored in the
+CLEANUP.md flags/usage section.
+
+---
+
+## Docusaurus site (misc/website/)
+
+Serves the GitHub Pages documentation. Content pages reference example READMEs.
+When adding a new example, add a corresponding sidebar entry. The site is built
+separately (`npm run build` in `misc/website/`); it does not affect terraform or
+cluster operations.
+
+---
+
+## Dependency summary: what feeds what
+
+```
+variables.tf ──► main.tf (locals) ──┬──► eks.tf ──┬──► setup.tf ──► .tpl ──► nodepools/
+                                    │             │
+                                    ├──► vpc.tf   ├──► tagging.tf
+                                    │             │
+                                    └──► alb-acm.tf ──► ingressclass.tf
+                                                  │
+                                                  └──► observability.tf
+```
+
+**Critical path for tagging:**
+```
+var.tags ──► local.tags ──┬──► provider default_tags (Layer 1)
+                          ├──► cluster_tags in eks.tf (Layer 2)
+                          ├──► templatefile() in setup.tf ──► .tpl spec.tags (Layer 3)
+                          ├──► tagSpecification in tagging.tf (Layer 4)
+                          └──► ingressclass_tags_yaml in ingressclass.tf (Layer 5)
+```
+
+All 5 layers source from the same `local.tags`. A tag key/value change in
+`variables.tf` propagates through all layers on `terraform apply` — but only
+to newly-created resources. Existing EC2/EBS/ALBs keep their original tags.
+
+---
+
+## Sources
+
+- [This repo (sample-aws-eks-auto-mode)](https://github.com/aws-samples/sample-aws-eks-auto-mode)
+- [EKS Auto Mode user guide](https://docs.aws.amazon.com/eks/latest/userguide/automode.html)
+- Internal: `terraform/setup.tf`, `nodepool-templates/*.yaml.tpl`, `.gitignore`

--- a/skills/eks-automode-maintain/references/tagging-consistency.md
+++ b/skills/eks-automode-maintain/references/tagging-consistency.md
@@ -1,0 +1,260 @@
+# Tagging Consistency — 5-Layer Verification Guide
+
+This reference covers how to verify all 5 tagging layers are aligned and
+debug when tags fail to land on AWS resources.
+
+---
+
+## Layer-by-layer verification
+
+### Layer 1: Provider default_tags
+
+**File:** `terraform/main.tf`
+
+```hcl
+provider "aws" {
+  default_tags {
+    tags = var.tags
+  }
+}
+```
+
+**What it tags:** All resources created directly by Terraform — VPC, subnets,
+NAT gateway, IAM roles, KMS keys, S3 buckets, Lambda functions, ACM certs,
+Route53 records (where supported), EKS cluster resource itself.
+
+**What it does NOT tag:**
+- EC2 instances launched by Karpenter/Auto Mode
+- EBS volumes created by the EBS CSI driver (PVC-provisioned)
+- ENIs created by the VPC CNI
+- ALBs/NLBs created by the ALB controller
+- Target groups, listeners, listener rules
+- Security groups created by the ALB controller or EKS networking
+- EKS primary security group (use `cluster_tags` instead)
+- EFS access points created by the EFS CSI driver
+
+**Verify:**
+```bash
+# Pick any TF-created resource and check tags
+aws ec2 describe-vpcs --filters "Name=tag:Blueprint,Values=$CLUSTER" \
+  --query 'Vpcs[].Tags'
+```
+
+---
+
+### Layer 2: EKS cluster_tags
+
+**File:** `terraform/eks.tf`
+
+```hcl
+module "eks" {
+  ...
+  cluster_tags = local.tags
+}
+```
+
+**What it tags:** The EKS-managed primary security group. This SG is created by
+the EKS service (not Terraform), so `default_tags` cannot reach it. The module
+uses `aws_ec2_tag` resources internally.
+
+**Verify:**
+```bash
+# Get the primary SG ID
+PRIMARY_SG=$(aws eks describe-cluster --name $CLUSTER \
+  --query 'cluster.resourcesVpcConfig.clusterSecurityGroupId' --output text)
+
+aws ec2 describe-tags --filters "Name=resource-id,Values=$PRIMARY_SG" \
+  --query 'Tags[?Key!=`aws:eks:cluster-name`]'
+```
+
+**Gotcha:** Pass tags as `cluster_tags`, not `tags`. The `tags` input on the
+module goes to the cluster resource itself (which `default_tags` already
+covers). `cluster_tags` specifically targets the primary SG via `aws_ec2_tag`.
+
+---
+
+### Layer 3: NodeClass spec.tags
+
+**Files:** `nodepool-templates/*.yaml.tpl`
+
+Each template includes:
+```yaml
+spec:
+  tags:
+    ${indent(4, yamlencode(tags))}
+```
+
+**What it tags:** EC2 instances, root EBS volumes, and ENIs launched by Auto
+Mode's built-in Karpenter for that NodeClass.
+
+**Verify:**
+```bash
+# Check running instances
+aws ec2 describe-instances \
+  --filters "Name=tag:aws:eks:cluster-name,Values=$CLUSTER" \
+            "Name=instance-state-name,Values=running" \
+  --query 'Reservations[].Instances[].[InstanceId,Tags[?Key==`auto-delete`].Value|[0]]' \
+  --output table
+```
+
+**Gotchas:**
+- Never patch the managed `default` NodeClass — EKS silently reverts custom
+  fields within minutes. Always use a named custom NodeClass.
+- NodePools must reference the custom NodeClass via `spec.template.spec.nodeClassRef.name`.
+- Tags only apply to instances launched AFTER the NodeClass is applied. Existing
+  nodes keep their original tags.
+
+**All templates must include spec.tags.** Verify coverage:
+```bash
+# Count templates vs templates with spec.tags (should match)
+ls nodepool-templates/*.yaml.tpl | wc -l
+grep -l 'spec.tags' nodepool-templates/*.yaml.tpl | wc -l
+```
+
+---
+
+### Layer 4: StorageClass tagSpecification
+
+**File:** `terraform/tagging.tf`
+
+```hcl
+parameters = merge(
+  { type = "gp3" },
+  { for i, k in keys(local.tags) : "tagSpecification_${i + 1}" => "${k}=${local.tags[k]}" },
+)
+```
+
+**What it tags:** EBS volumes created by PVCs that use the `ebs` StorageClass
+(set as default). Volumes from the managed `auto-ebs-sc` class remain untagged
+(managed StorageClass cannot be mutated).
+
+**Verify:**
+```bash
+# Check PVC-created volumes
+aws ec2 describe-volumes \
+  --filters "Name=tag:kubernetes.io/created-by,Values=ebs.csi.eks.amazonaws.com" \
+  --query 'Volumes[].[VolumeId,Tags[?Key==`auto-delete`].Value|[0]]' \
+  --output table
+```
+
+**Gotchas:**
+- StorageClass `parameters` are **immutable**. `kubectl apply` on a changed
+  StorageClass errors. You must `kubectl delete storageclass ebs` then recreate.
+  Terraform handles this with `kubectl_manifest` force behavior.
+- Existing PVCs/volumes keep their original tags. Only new PVCs get updated tags.
+- The legacy `gp2` StorageClass is deleted by `null_resource.delete_gp2_storageclass`
+  so PVCs without an explicit `storageClassName` land on the tagged `ebs` class.
+
+---
+
+### Layer 5: IngressClassParams spec.tags
+
+**File:** `terraform/ingressclass.tf`
+
+```yaml
+spec:
+  tags:
+    - key: auto-delete
+      value: never
+```
+
+(Rendered dynamically from `local.tags` via `ingressclass_tags_yaml` local.)
+
+**What it tags:** ALBs, target groups, listeners, and listener-rule security
+groups created by Auto Mode's built-in ALB controller for Ingresses using the
+`alb` IngressClass.
+
+**Verify:**
+```bash
+# List ALBs and their tags
+for arn in $(aws elbv2 describe-load-balancers \
+  --query 'LoadBalancers[].LoadBalancerArn' --output text); do
+  echo "=== $arn ==="
+  aws elbv2 describe-tags --resource-arns $arn --query 'TagDescriptions[].Tags'
+done
+```
+
+**Gotchas:**
+- IngressClassParams is per-class. If you have multiple IngressClasses (e.g.
+  internal + internet-facing), each needs its own IngressClassParams with tags.
+- This file has two mutually-exclusive branches gated on `local.enable_domain`.
+  Both branches include `spec.tags`.
+
+---
+
+## IAM requirement: enable_auto_mode_custom_tags
+
+Layers 3-5 call AWS APIs under the cluster IAM role. The managed policies only
+allow `eks:*`, `kubernetes.io/*`, `karpenter.sh/*` tag keys by default. Custom
+keys (like `auto-delete`) are DENIED without an additional IAM policy.
+
+**Fix:** `enable_auto_mode_custom_tags = true` on the EKS module (default since
+v20.31). Verify in `terraform/eks.tf`:
+
+```bash
+grep 'enable_auto_mode_custom_tags' terraform/eks.tf
+```
+
+If this is `false` or missing, Layers 3-5 silently fail — resources create
+successfully but without your custom tags.
+
+---
+
+## Known gap: LoadBalancer-type Services
+
+There is no cluster-wide default for LoadBalancer-type Service tags. Each
+Service manifest must carry the annotation:
+
+```yaml
+metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "auto-delete=never"
+```
+
+This is documented in `claude-md/TAGGING.md`. Remind contributors to add this
+annotation when creating LoadBalancer Services in examples.
+
+---
+
+## Debugging: tag not landing?
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| New EC2 instances untagged | IAM policy missing | Verify `enable_auto_mode_custom_tags = true` |
+| EC2 tagged but old ones not | Tags are create-time only | Retag with `aws ec2 create-tags` |
+| NodeClass tags revert | Patched managed `default` NodeClass | Use custom NodeClass; delete any patches |
+| StorageClass change rejected | Parameters immutable | Delete and recreate StorageClass |
+| CloudTrail shows `UnauthorizedOperation` | IAM allowlist doesn't include your key | Check custom tag IAM policy attachment |
+| ALB missing tags | Wrong IngressClass or IngressClassParams | Verify Ingress specifies `ingressClassName: alb` |
+| Primary SG untagged | Using `tags` instead of `cluster_tags` | Pass via `cluster_tags` on module block |
+
+**CloudTrail query for tag failures:**
+```bash
+aws cloudtrail lookup-events \
+  --lookup-attributes AttributeKey=EventName,AttributeValue=RunInstances \
+  --query 'Events[?contains(CloudTrailEvent, `UnauthorizedOperation`)].CloudTrailEvent' \
+  --max-results 5 --output text | jq -r '.errorMessage' 2>/dev/null
+```
+
+---
+
+## Adding a new tag key
+
+When adding a tag key across the repo:
+
+1. Add to `var.tags` default in `variables.tf` (or instruct users to pass it).
+2. Run `terraform apply` — this propagates through all 5 layers automatically
+   because they all source from `local.tags`.
+3. Verify with the per-layer commands above.
+4. Update `claude-md/TAGGING.md` if the new key has special semantics.
+5. Existing resources remain untagged — retag imperatively if needed.
+
+---
+
+## Sources
+
+- [Tag propagation IAM policy](https://docs.aws.amazon.com/eks/latest/userguide/auto-cluster-iam-role.html#tag-prop)
+- [Custom NodeClass creation](https://docs.aws.amazon.com/eks/latest/userguide/create-node-class.html)
+- [EKS Auto Mode best practices](https://docs.aws.amazon.com/eks/latest/best-practices/automode.html)
+- [This repo (sample-aws-eks-auto-mode)](https://github.com/aws-samples/sample-aws-eks-auto-mode)
+- Internal: `claude-md/TAGGING.md`, `terraform/tagging.tf`, `terraform/ingressclass.tf`, `terraform/eks.tf`

--- a/skills/eks-automode-onboard/SKILL.md
+++ b/skills/eks-automode-onboard/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: eks-automode-onboard
+description: >
+  Onboarding guide for EKS Auto Mode newcomers. Use this skill when the user asks
+  about EKS Auto Mode concepts, wants to deploy their first Auto Mode cluster using
+  this repo, needs help picking an example, or hits common first-day issues. Trigger
+  phrases: "what is Auto Mode", "how do I deploy", "which example should I use",
+  "getting started with EKS Auto Mode", "first cluster", "deploy this repo",
+  "Auto Mode tutorial", "newbie", "onboard", "walkthrough".
+---
+
+# EKS Auto Mode Onboarding
+
+Help users go from zero to a running EKS Auto Mode cluster using this repository.
+Cover concepts, deployment, example selection, and first-encounter troubleshooting.
+
+## What EKS Auto Mode manages for you
+
+EKS Auto Mode runs these components inside the AWS-managed control plane so you never
+install, configure, or upgrade them:
+
+| Component | What it does |
+|-----------|--------------|
+| Karpenter | Provisions, scales, and consolidates EC2 compute |
+| VPC CNI | Pod networking, IP allocation, security groups |
+| EBS CSI driver | Persistent volume provisioning from PVCs |
+| ALB controller | Creates ALBs/NLBs from Ingress and Service resources |
+| CoreDNS | Cluster DNS (runs as a node-level service, not pods) |
+| Pod Identity Agent | Fine-grained IAM for pods without manual IRSA |
+| Node health monitor | Detects and replaces unhealthy nodes |
+| AMI lifecycle | Picks correct AMI, patches weekly, remediates drift |
+
+You interact via standard K8s APIs (NodePool, NodeClass, Ingress, StorageClass).
+AWS handles the operational lifecycle behind those APIs.
+
+## Which example should I use?
+
+| Use case | Example directory | What it deploys |
+|----------|-------------------|-----------------|
+| First deployment / validation | `examples/graviton/` | 2048 game on ARM64 Graviton |
+| Fault-tolerant batch / dev | `examples/spot/` | 2048 game on Spot instances |
+| ML inference (NVIDIA GPU) | `examples/gpu/` | Qwen 3 on GPU |
+| ML inference (Inferentia2) | `examples/neuron/` | DeepSeek-R1-Qwen3-8B via vLLM |
+| OD + Spot mix with headroom | `examples/cost-optimization/` | Weighted priority pools + pause-pod |
+| Pin to reserved capacity | `examples/capacity-reservation/` | ODCR-targeted NodePool |
+| Fixed always-on fleet | `examples/static-capacity/` | `spec.replicas` nodes, no consolidation |
+| Protect long-running jobs | `examples/batch-jobs/` | `do-not-disrupt` annotation pattern |
+| Limit drain concurrency | `examples/disruption-budgets/` | NodePool disruption budget config |
+| CPU autoscaling + SQS-driven | `examples/pod-autoscaling/` | HPA + KEDA ScaledObjects |
+| Metrics, logs, tracing | `examples/observability/` | CloudWatch Container Insights |
+
+Start with `examples/graviton/` if you just want to validate the cluster works.
+
+## Deployment steps
+
+### 1. Clone
+
+```bash
+git clone https://github.com/aws-samples/sample-aws-eks-auto-mode.git && cd sample-aws-eks-auto-mode
+```
+
+### 2. Configure variables
+
+Edit `terraform/terraform.tfvars` (or pass `-var` flags). The important variables:
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `name` | Cluster and VPC name | `automode-cluster` |
+| `region` | AWS region | `us-west-2` |
+| `eks_cluster_version` | K8s version (minimum 1.29 for Auto Mode) | `1.34` |
+| `tags` | Tags applied everywhere via 5-layer pattern | `{"auto-delete"="never"}` |
+| `base_domain` | Route53 zone for public HTTPS (leave empty for internal-only) | `""` |
+| `enable_observability` | CloudWatch Container Insights | `false` |
+
+### 3. Deploy
+
+```bash
+cd terraform && terraform init && terraform apply -auto-approve
+```
+
+Terraform creates the VPC, EKS cluster, IAM roles, NodePools, NodeClasses,
+StorageClasses, and IngressClasses. Takes 12-18 minutes.
+
+### 4. Configure kubectl
+
+```bash
+$(terraform output -raw configure_kubectl)
+```
+
+### 5. Validate
+
+```bash
+kubectl get nodes                   # Should show zero nodes (no workloads yet)
+kubectl get nodepools               # Shows general-purpose + any custom pools
+kubectl get nodeclasses             # Shows default + any custom classes
+kubectl get storageclass            # Should list ebs-csi class
+kubectl get ingressclass            # Should list alb class
+```
+
+### 6. Deploy an example
+
+```bash
+kubectl apply -f examples/graviton/
+kubectl get pods -n game-2048 -w    # Watch Auto Mode provision a Graviton node
+```
+
+A node appears within 60-90 seconds. The pod transitions to Running once the node
+joins and passes readiness checks.
+
+## Key concepts
+
+### What you manage vs what AWS manages
+
+| You manage | AWS manages |
+|------------|-------------|
+| NodePool specs (instance families, AZs, taints) | Actual instance launches + termination |
+| NodeClass specs (tags, storage config) | AMI selection, patching, drift remediation |
+| Ingress / Service manifests | ALB/NLB creation, TLS termination, target registration |
+| PVC manifests + StorageClass | EBS volume provisioning, attach, detach |
+| Pod specs and scheduling constraints | Node health monitoring + auto-repair |
+| Cluster version upgrades (EKS console/API) | Component version upgrades (Karpenter, CNI, CSI, CoreDNS) |
+
+### NodePool and NodeClass relationship
+
+```
+NodePool (what to launch)         NodeClass (how to launch)
+- instance families               - subnet discovery rules
+- architectures (amd64/arm64)     - security group discovery
+- capacity types (on-demand/spot) - ephemeral storage config
+- taints and labels               - tags pushed to EC2/EBS/ENI
+- disruption settings             - IMDS settings
+- weight (priority)               - KMS key for storage
+        |                                  |
+        +---- nodeClassRef.name -----------+
+```
+
+A NodePool references exactly one NodeClass. Multiple NodePools can share a NodeClass.
+
+The `default` NodePool and `default` NodeClass are AWS-managed. Do not edit the
+`default` NodeClass (changes revert silently within minutes). Create custom
+NodeClasses for durable customization.
+
+### Templatefile rendering chain
+
+This repo uses Terraform's `templatefile()` to render K8s manifests:
+
+```
+nodepool-templates/*.yaml.tpl  (source templates)
+       |
+       v  terraform apply (templatefile + local_file)
+       |
+nodepools/*.yaml  (rendered manifests applied by kubectl_manifest)
+```
+
+If you edit a `.tpl` file, the rendered YAML does not update until you run
+`terraform apply`. Never edit the rendered YAML directly; it will be overwritten.
+
+## Common gotchas for newcomers
+
+1. **Pods stuck Pending** -- check `nodeSelector` and `node.kubernetes.io/instance-type`
+   labels. Auto Mode only provisions nodes that match a NodePool. If no pool matches
+   your pod's constraints, it stays Pending forever.
+
+2. **EBS StorageClass provisioner name** -- use `ebs.csi.eks.amazonaws.com`, NOT
+   `ebs.csi.aws.com`. The latter is the self-managed driver. Auto Mode uses a
+   different provisioner name.
+
+3. **Editing the default NodeClass** -- your changes revert silently. Always create
+   a named custom NodeClass.
+
+4. **Tags not landing on resources** -- you need the IAM custom-tags policy
+   (`enable_auto_mode_custom_tags=true` in the module). Without it, any custom tag
+   key outside `eks:*`, `kubernetes.io/*`, `karpenter.sh/*` is silently denied.
+
+5. **No SSH/SSM access to nodes** -- nodes are Bottlerocket and read-only. Use
+   `kubectl debug node/<name>` or the NodeDiagnostic resource for troubleshooting.
+
+6. **Rendered YAML stale after template edit** -- run `terraform apply` to
+   re-render. Applying stale YAML silently reverts your fix.
+
+7. **LB not provisioning** -- subnets need `kubernetes.io/role/elb: "1"` (public)
+   or `kubernetes.io/role/internal-elb: "1"` (private) tags. This repo adds them
+   automatically, but custom VPCs may not.
+
+## When to use the detailed references
+
+- **Concepts deep-dive** (managed components, instance families, IMDS, disruption model):
+  see `references/concepts.md`
+- **Full deployment walkthrough** (prerequisites, variable reference, post-deploy validation,
+  cleanup): see `references/deployment-guide.md`
+- **Troubleshooting** (Pending pods, node join failures, tag issues, LB problems,
+  storage errors): see `references/troubleshooting.md`
+- **Tagging patterns** (5-layer model, IAM policy, known gaps): see `claude-md/TAGGING.md`
+- **Cleanup/teardown** (drain order, orphan sweep, post-destroy verification):
+  see `claude-md/CLEANUP.md`
+
+## Sources
+
+- [EKS Auto Mode overview](https://docs.aws.amazon.com/eks/latest/userguide/automode.html)
+- [Auto Mode reference](https://docs.aws.amazon.com/eks/latest/userguide/auto-reference.html)
+- [Instance types in Auto Mode](https://docs.aws.amazon.com/eks/latest/userguide/automode-learn-instances.html)
+- [Create a NodePool](https://docs.aws.amazon.com/eks/latest/userguide/create-node-pool.html)
+- [Create a NodeClass](https://docs.aws.amazon.com/eks/latest/userguide/create-node-class.html)
+- [Configure ALB](https://docs.aws.amazon.com/eks/latest/userguide/auto-configure-alb.html)
+- [Create StorageClass](https://docs.aws.amazon.com/eks/latest/userguide/create-storage-class.html)
+- [Troubleshooting Auto Mode](https://docs.aws.amazon.com/eks/latest/userguide/auto-troubleshoot.html)
+- [Best practices for Auto Mode](https://docs.aws.amazon.com/eks/latest/best-practices/automode.html)
+- [This repository](https://github.com/aws-samples/sample-aws-eks-auto-mode)

--- a/skills/eks-automode-onboard/references/concepts.md
+++ b/skills/eks-automode-onboard/references/concepts.md
@@ -1,0 +1,200 @@
+# EKS Auto Mode -- Concepts
+
+## What Auto Mode manages
+
+EKS Auto Mode runs the following as managed control-plane components. You do not
+install, configure, upgrade, or monitor any of them directly:
+
+| Component | Responsibility |
+|-----------|---------------|
+| Karpenter | Compute provisioning, scaling, consolidation, drift remediation |
+| VPC CNI | Pod networking, IP address management, security group enforcement |
+| EBS CSI driver | PersistentVolume provisioning and lifecycle (provisioner: `ebs.csi.eks.amazonaws.com`) |
+| ALB controller | Application and Network Load Balancer creation from Ingress/Service |
+| CoreDNS | Cluster DNS resolution (runs as node-level service, not user-visible pods) |
+| Pod Identity Agent | IAM credential injection for pods (replaces manual IRSA setup) |
+| kube-proxy | Per-node network rules for Service routing |
+| Node monitoring | Health checks, automatic repair/replacement of failed nodes |
+
+All components receive automatic version upgrades independent of your cluster version.
+You never see a Helm release or DaemonSet for these.
+
+## Shared responsibility model
+
+| AWS manages | You manage |
+|-------------|------------|
+| Component installation and upgrades | Cluster version (initiate upgrade via console/API) |
+| AMI selection, patching (~weekly) | NodePool definitions (what to launch) |
+| Node health and replacement | NodeClass customization (how to launch) |
+| Instance termination for drift/expiry | Workload scheduling constraints |
+| Load balancer provisioning | Ingress/Service manifests |
+| Volume provisioning and attach | PVC definitions and StorageClass selection |
+| DNS resolution (CoreDNS) | Application-level DNS (external-dns is opt-in) |
+| Security patching | IAM roles and policies for your workloads |
+
+## NodePool vs NodeClass
+
+### NodePool (what to launch)
+
+Defines compute constraints that Karpenter uses to select instances:
+
+- `spec.template.spec.requirements` -- instance families, architectures (amd64/arm64),
+  capacity types (on-demand/spot), availability zones
+- `spec.template.metadata.labels` -- labels applied to every node from this pool
+- `spec.template.spec.taints` -- taints applied to nodes
+- `spec.disruption` -- consolidation policy, budgets, expireAfter
+- `spec.weight` -- priority when multiple pools match (higher wins)
+- `spec.limits` -- resource ceilings (CPU, memory)
+
+### NodeClass (how to launch)
+
+Defines the infrastructure blueprint for the EC2 instance:
+
+- `spec.subnetSelectorTerms` -- discover subnets by tags
+- `spec.securityGroupSelectorTerms` -- discover security groups by tags
+- `spec.tags` -- tags pushed to EC2 instances, root EBS volumes, and ENIs
+- `spec.ephemeral` -- ephemeral storage configuration (size, IOPS, throughput, encryption)
+- `spec.role` -- IAM role for the node (usually the cluster node role)
+
+API version: `eks.amazonaws.com/v1`
+
+### Default vs custom
+
+EKS creates a managed `default` NodePool and `default` NodeClass. These cover
+general-purpose workloads out of the box. Key rules:
+
+- The `default` NodeClass is reconciled by EKS. Edits revert silently within minutes.
+- Create a named custom NodeClass for any durable customization (tags, storage, etc.).
+- Custom NodePools must set `spec.template.spec.nodeClassRef.name` to your custom
+  NodeClass (or the `default` if no customization is needed).
+- The `default` NodePool can be reconfigured via `set-builtin-node-pools` API or
+  by applying a NodePool manifest with `metadata.name: general-purpose`.
+
+## 5-layer tagging pattern
+
+Tags reach different resource types through different mechanisms. A single
+`provider { default_tags {} }` is insufficient. The 5 layers:
+
+1. **Provider `default_tags`** -- Terraform-direct resources (VPC, subnets, IAM, KMS)
+2. **`cluster_tags`** -- EKS primary security group (via `aws_ec2_tag`)
+3. **NodeClass `spec.tags`** -- EC2 instances, root EBS, ENIs launched by Karpenter
+4. **StorageClass `tagSpecification`** -- EBS volumes from PVCs
+5. **IngressClassParams `spec.tags`** -- ALBs, target groups, listeners, SGs
+
+Each layer requires its own configuration. The IAM custom-tags policy
+(`enable_auto_mode_custom_tags=true`) is load-bearing for layers 3-5; without it,
+custom tag keys are silently denied.
+
+Full reference: `claude-md/TAGGING.md` in this repository.
+
+## Instance families supported
+
+Auto Mode supports a broad set of instance families:
+
+- **General purpose**: M5, M5a, M5ad, M5d, M5n, M6a, M6g, M6gd, M6i, M6id, M6in, M7a, M7g, M7gd, M7i, M7i-flex, M8g
+- **Compute optimized**: C5, C5a, C5ad, C5d, C5n, C6a, C6g, C6gd, C6gn, C6i, C6id, C6in, C7a, C7g, C7gd, C7gn, C7i, C7i-flex, C8g
+- **Memory optimized**: R5, R5a, R5ad, R5b, R5d, R5n, R6a, R6g, R6gd, R6i, R6id, R6in, R7a, R7g, R7gd, R7i, R7iz, R8g
+- **Accelerated (GPU)**: G5, G6, G6e, Gr6, P4d, P4de, P5, P5e
+- **Accelerated (Inferentia/Trainium)**: Inf2, Trn1, Trn1n, Trn2
+- **Storage optimized**: I3, I3en, I4g, I4i, Im4gn, Is4gen
+- **HPC**: Hpc6a, Hpc6id, Hpc7a, Hpc7g
+
+Availability varies by region. NodePool `requirements` filter to your desired subset.
+
+## Ephemeral storage and NVMe behavior
+
+- Every Auto Mode node has an EBS root volume for ephemeral storage (OS, container
+  images, emptyDir volumes).
+- Instance types with local NVMe (d-suffix families like M6gd, C6id) expose NVMe as
+  additional ephemeral storage automatically.
+- Default root volume: 80 GiB gp3. Configurable via NodeClass `spec.ephemeral`.
+- Ephemeral storage is encrypted. Use `ephemeral_storage_kms_key_id` variable for
+  custom KMS keys.
+- emptyDir volumes consume ephemeral storage. Large emptyDirs can cause node pressure.
+
+## IMDS restrictions
+
+- IMDSv2 is enforced (IMDSv1 disabled).
+- Hop limit is 1 (only the node itself can reach IMDS; containers cannot by default).
+- Pods use Pod Identity for AWS credentials, not instance metadata.
+- If a workload genuinely needs IMDS access, it requires a hostNetwork pod (not
+  recommended; use Pod Identity instead).
+
+## What is NOT supported
+
+- **SSH access** -- nodes are Bottlerocket, read-only filesystem, no SSH daemon
+- **SSM Session Manager** -- not installed on Auto Mode nodes
+- **Custom AMIs** -- you cannot specify your own AMI; AWS selects and patches
+- **Windows nodes** -- Auto Mode is Linux (Bottlerocket) only
+- **DaemonSets for managed components** -- they run in the control plane, not on nodes
+- **Instance store as PV** -- local NVMe is ephemeral only, not usable for PVCs
+- **More than 110 pods per node** -- hard limit from the kubelet configuration
+
+## Key labels
+
+Auto Mode nodes carry these labels (non-exhaustive):
+
+| Label | Values | Purpose |
+|-------|--------|---------|
+| `eks.amazonaws.com/compute-type` | `auto` | Identifies Auto Mode nodes |
+| `node.kubernetes.io/instance-type` | e.g., `m6g.xlarge` | Standard K8s label |
+| `topology.kubernetes.io/zone` | e.g., `us-west-2a` | AZ placement |
+| `kubernetes.io/arch` | `amd64`, `arm64` | CPU architecture |
+| `kubernetes.io/os` | `linux` | OS (always linux) |
+| `karpenter.sh/capacity-type` | `on-demand`, `spot` | Capacity type |
+| `karpenter.sh/nodepool` | pool name | Which NodePool launched this node |
+| `eks.amazonaws.com/nodeclass` | class name | Which NodeClass was used |
+
+Use `eks.amazonaws.com/compute-type: auto` in nodeSelector or affinity to target
+Auto Mode nodes specifically (useful during migration from Standard Mode).
+
+## Disruption model
+
+Auto Mode's Karpenter continuously optimizes the fleet. Four disruption reasons:
+
+### Consolidation
+
+Removes underutilized nodes or replaces them with cheaper/smaller instances.
+Respects PodDisruptionBudgets and `do-not-disrupt` annotations.
+
+### Drift
+
+When a NodePool or NodeClass spec changes, existing nodes no longer match. Karpenter
+drains and replaces them. Also triggers when AWS updates the AMI.
+
+### Expiration
+
+Nodes have a maximum lifetime (`spec.disruption.expireAfter`). Default: 336h (14 days).
+After expiry, nodes are cordoned and drained. Prevents configuration drift.
+
+### Disruption budgets
+
+`spec.disruption.budgets` controls how many nodes can be disrupted simultaneously:
+
+```yaml
+spec:
+  disruption:
+    budgets:
+      - nodes: "10%"     # Max 10% of pool disrupted at once
+      - nodes: "0"       # During this schedule, no disruption
+        schedule: "0 9 * * 1-5"  # Weekdays 9 AM
+        duration: 8h             # For 8 hours
+```
+
+Budgets protect availability during maintenance. Set `nodes: "0"` during business
+hours if needed.
+
+## Sources
+
+- [EKS Auto Mode overview](https://docs.aws.amazon.com/eks/latest/userguide/automode.html)
+- [Auto Mode reference](https://docs.aws.amazon.com/eks/latest/userguide/auto-reference.html)
+- [Instance types in Auto Mode](https://docs.aws.amazon.com/eks/latest/userguide/automode-learn-instances.html)
+- [Auto Mode IAM](https://docs.aws.amazon.com/eks/latest/userguide/auto-learn-iam.html)
+- [Auto Mode networking](https://docs.aws.amazon.com/eks/latest/userguide/auto-networking.html)
+- [Create a NodePool](https://docs.aws.amazon.com/eks/latest/userguide/create-node-pool.html)
+- [Create a NodeClass](https://docs.aws.amazon.com/eks/latest/userguide/create-node-class.html)
+- [Set built-in NodePools](https://docs.aws.amazon.com/eks/latest/userguide/set-builtin-node-pools.html)
+- [On-Demand Capacity Reservations](https://docs.aws.amazon.com/eks/latest/userguide/auto-odcr.html)
+- [Migrate to Auto Mode](https://docs.aws.amazon.com/eks/latest/userguide/migrate-auto.html)
+- [Best practices for Auto Mode](https://docs.aws.amazon.com/eks/latest/best-practices/automode.html)
+- [This repository](https://github.com/aws-samples/sample-aws-eks-auto-mode)

--- a/skills/eks-automode-onboard/references/deployment-guide.md
+++ b/skills/eks-automode-onboard/references/deployment-guide.md
@@ -1,0 +1,273 @@
+# EKS Auto Mode -- Deployment Guide
+
+Complete walkthrough for deploying an EKS Auto Mode cluster using this repository.
+
+## Prerequisites
+
+### Required tools
+
+| Tool | Minimum version | Purpose |
+|------|-----------------|---------|
+| AWS CLI | v2.x | AWS API access, kubectl config |
+| Terraform | >= 1.5 | Infrastructure provisioning |
+| kubectl | >= 1.29 | Cluster interaction |
+
+### Optional tools
+
+| Tool | Purpose |
+|------|---------|
+| Helm | Only if deploying KEDA example (pod-autoscaling) |
+| jq | JSON parsing for validation commands |
+
+### AWS account requirements
+
+- An AWS account with permissions to create VPC, EKS, IAM, EC2, EBS, ELB, KMS,
+  CloudWatch, and Route53 resources.
+- A region that supports EKS Auto Mode (most commercial regions do; check the
+  regional availability table in the EKS documentation).
+- If using `base_domain`: a public Route53 hosted zone that already exists and is
+  authoritative for that domain.
+
+### Authentication
+
+Configure AWS credentials before running Terraform:
+
+```bash
+aws sts get-caller-identity
+```
+
+This must return a valid identity with sufficient permissions.
+
+## Variable reference
+
+All inputs live in `terraform/variables.tf`. Override via `-var` flags or
+`terraform/terraform.tfvars`.
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `name` | string | `automode-cluster` | Name for VPC and EKS cluster. Used in resource naming and tag discovery. |
+| `region` | string | `us-west-2` | AWS region to deploy into. |
+| `eks_cluster_version` | string | `1.34` | EKS K8s version. Auto Mode requires 1.29+. |
+| `vpc_cidr` | string | `10.0.0.0/16` | VPC CIDR block. 65536 IPs across 3 AZs. |
+| `tags` | map(string) | `{"auto-delete"="never"}` | Tags applied via 5-layer pattern to all taggable resources. |
+| `base_domain` | string | `""` | Public Route53 zone for HTTPS. Leave empty for internal-only (safe default). |
+| `subdomain` | string | `""` | Optional prefix under `base_domain`. Ignored when `base_domain` is empty. |
+| `ephemeral_storage_kms_key_id` | string | `""` | KMS key ID for node ephemeral storage encryption. |
+| `enable_observability` | bool | `false` | Enable CloudWatch Container Insights (incurs costs). |
+
+### Minimal deploy (all defaults)
+
+No tfvars file needed. Just run `terraform apply`.
+
+### Production-like deploy
+
+```hcl
+# terraform/terraform.tfvars
+name                  = "my-cluster"
+region                = "eu-west-1"
+eks_cluster_version   = "1.34"
+tags                  = { "team" = "platform", "env" = "staging", "auto-delete" = "7d" }
+base_domain           = "example.com"
+subdomain             = "eks"
+enable_observability  = true
+```
+
+## Deploy steps
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/aws-samples/sample-aws-eks-auto-mode.git && cd sample-aws-eks-auto-mode
+```
+
+### 2. Initialize Terraform
+
+```bash
+cd terraform && terraform init
+```
+
+Downloads providers (AWS, Kubernetes, Helm, kubectl) and the EKS module.
+
+### 3. Plan (optional but recommended)
+
+```bash
+terraform plan -out=tfplan
+```
+
+Review the plan to understand what will be created (~45-60 resources for the base
+cluster).
+
+### 4. Apply
+
+```bash
+terraform apply tfplan    # if you saved a plan
+# or
+terraform apply -auto-approve
+```
+
+Takes 12-18 minutes. The EKS cluster creation is the longest step (~10 min).
+
+### 5. Configure kubectl
+
+```bash
+$(terraform output -raw configure_kubectl)
+```
+
+This runs `aws eks update-kubeconfig` with the correct cluster name and region.
+
+## Post-deploy validation
+
+Run these commands to confirm the cluster is healthy:
+
+```bash
+# Cluster reachable
+kubectl cluster-info
+
+# No nodes yet (Auto Mode provisions on demand)
+kubectl get nodes
+
+# NodePools ready
+kubectl get nodepools
+
+# NodeClasses present
+kubectl get nodeclasses
+
+# StorageClass exists with correct provisioner
+kubectl get sc -o custom-columns='NAME:.metadata.name,PROVISIONER:.provisioner'
+# Expected: provisioner = ebs.csi.eks.amazonaws.com
+
+# IngressClass present
+kubectl get ingressclass
+
+# Karpenter CRDs installed
+kubectl api-resources | grep karpenter
+```
+
+If any of these fail, check `terraform output` for errors and verify your AWS
+credentials are active.
+
+## Deploying examples
+
+Each example is a self-contained directory under `examples/`. Most are pure
+kubectl-apply; some require Terraform (KEDA in pod-autoscaling).
+
+### kubectl-based examples
+
+```bash
+kubectl apply -f examples/graviton/
+kubectl apply -f examples/spot/
+kubectl apply -f examples/gpu/
+kubectl apply -f examples/neuron/
+kubectl apply -f examples/cost-optimization/
+kubectl apply -f examples/capacity-reservation/
+kubectl apply -f examples/static-capacity/
+kubectl apply -f examples/batch-jobs/
+kubectl apply -f examples/disruption-budgets/
+```
+
+After applying, watch pods:
+
+```bash
+kubectl get pods -A -w
+```
+
+A node provisions within 60-90 seconds, and the pod starts shortly after.
+
+### Terraform-based examples
+
+The pod-autoscaling example (KEDA) has its own Terraform root:
+
+```bash
+cd examples/pod-autoscaling/terraform && terraform init && terraform apply -auto-approve
+```
+
+### Example purposes
+
+| Example | Demonstrates |
+|---------|-------------|
+| graviton | ARM64 scheduling, nodeSelector for architecture |
+| spot | Spot capacity type, diverse instance families for availability |
+| gpu | GPU nodeSelector, NVIDIA device plugin (managed), tolerations |
+| neuron | Inferentia2 scheduling, neuron device plugin, vLLM serving |
+| cost-optimization | Weighted NodePool priority, pause-pod overprovision buffer |
+| capacity-reservation | ODCR targeting via NodePool requirements |
+| static-capacity | `spec.replicas` for fixed fleet, consolidation immunity |
+| batch-jobs | `karpenter.sh/do-not-disrupt` annotation, dedicated pool |
+| disruption-budgets | `spec.disruption.budgets` configuration patterns |
+| pod-autoscaling | HPA (CPU) + KEDA (SQS queue depth) scaling |
+| observability | Container Insights addon, log groups, Application Signals |
+
+## Optional features
+
+### Public HTTPS exposure (base_domain)
+
+Setting `base_domain` enables:
+- ACM wildcard certificate for `*.<subdomain>.<base_domain>`
+- external-dns installation with Pod Identity
+- Internet-facing ALB (shared across examples)
+- Automatic DNS record creation for each Ingress host
+
+```bash
+terraform apply -var='base_domain=example.com' -var='subdomain=automode'
+```
+
+The hosted zone must already exist. Terraform does not create it.
+
+### Observability (Container Insights)
+
+```bash
+terraform apply -var='enable_observability=true'
+```
+
+Installs the CloudWatch Observability EKS addon. Provides:
+- Container-level CPU, memory, network metrics
+- Pod log forwarding to CloudWatch Logs
+- Application Signals distributed tracing
+
+Incurs CloudWatch costs proportional to cluster size and log volume.
+
+### Ephemeral storage encryption
+
+```bash
+terraform apply -var='ephemeral_storage_kms_key_id=arn:aws:kms:us-west-2:123456789012:key/abc-123'
+```
+
+Encrypts the root EBS volume on every Auto Mode node with your KMS key.
+
+## Cleanup procedure
+
+Use the included cleanup script for safe teardown. It drains K8s-managed AWS
+resources before destroying Terraform state, then sweeps for orphans.
+
+```bash
+# Preview what would be deleted
+./scripts/cleanup.sh --dry-run
+
+# Full non-interactive teardown
+./scripts/cleanup.sh --yes
+
+# Keep storage (PVCs/EBS volumes preserved)
+./scripts/cleanup.sh --yes --keep-storage
+
+# Orphan sweep only (Terraform already destroyed)
+./scripts/cleanup.sh --skip-terraform --cluster-name <name> --region <region>
+```
+
+Do not run bare `terraform destroy` alone. It leaves orphaned ALBs, EBS volumes,
+ENIs, and security groups created by in-cluster controllers. The cleanup script
+handles these properly.
+
+Full teardown reference: `claude-md/CLEANUP.md` in this repository.
+
+## Sources
+
+- [EKS Auto Mode overview](https://docs.aws.amazon.com/eks/latest/userguide/automode.html)
+- [Auto Mode reference](https://docs.aws.amazon.com/eks/latest/userguide/auto-reference.html)
+- [Configure ALB](https://docs.aws.amazon.com/eks/latest/userguide/auto-configure-alb.html)
+- [Configure NLB](https://docs.aws.amazon.com/eks/latest/userguide/auto-configure-nlb.html)
+- [Create StorageClass](https://docs.aws.amazon.com/eks/latest/userguide/create-storage-class.html)
+- [Tag subnets for Auto Mode](https://docs.aws.amazon.com/eks/latest/userguide/tag-subnets-auto.html)
+- [Static capacity](https://docs.aws.amazon.com/eks/latest/userguide/auto-static-capacity.html)
+- [Migrate to Auto Mode](https://docs.aws.amazon.com/eks/latest/userguide/migrate-auto.html)
+- [Best practices for Auto Mode](https://docs.aws.amazon.com/eks/latest/best-practices/automode.html)
+- [This repository](https://github.com/aws-samples/sample-aws-eks-auto-mode)

--- a/skills/eks-automode-onboard/references/troubleshooting.md
+++ b/skills/eks-automode-onboard/references/troubleshooting.md
@@ -1,0 +1,355 @@
+# EKS Auto Mode -- Troubleshooting
+
+Common issues encountered when first deploying and operating an EKS Auto Mode cluster.
+
+## Pods stuck Pending
+
+### Symptoms
+
+Pod stays in `Pending` state. `kubectl describe pod` shows:
+```
+Events:
+  Warning  FailedScheduling  ... 0/0 nodes are available: ...
+```
+
+No NodeClaim is created, or a NodeClaim is created but no node appears.
+
+### Diagnosis
+
+```bash
+# Check if any NodePool matches the pod's requirements
+kubectl get nodepools -o yaml | grep -A 20 'requirements:'
+
+# Check pod's nodeSelector and affinity
+kubectl get pod <name> -n <ns> -o jsonpath='{.spec.nodeSelector}'
+kubectl get pod <name> -n <ns> -o jsonpath='{.spec.affinity}'
+
+# Look for NodeClaims (Karpenter's intent to launch)
+kubectl get nodeclaims
+```
+
+### Common causes
+
+1. **Missing `eks.amazonaws.com/compute-type: auto` label match** -- if your NodePool
+   has this requirement but the pod doesn't select it (or vice versa).
+
+2. **Architecture mismatch** -- pod image is amd64-only but NodePool only allows
+   arm64 (or vice versa). Check `kubernetes.io/arch` in requirements.
+
+3. **No NodePool allows the requested instance type** -- if your pod uses
+   `node.kubernetes.io/instance-type` in nodeSelector, a NodePool must include that
+   family in its requirements.
+
+4. **Resource requests exceed largest allowed instance** -- a pod requesting 512Gi
+   memory with a NodePool limited to M5 family (max 384 GiB) can never schedule.
+
+5. **Taint without toleration** -- NodePool applies taints that the pod doesn't
+   tolerate.
+
+### Fix
+
+Ensure at least one NodePool's requirements are a superset of the pod's scheduling
+constraints. If you are unsure, remove the nodeSelector temporarily and see if the
+pod schedules.
+
+## Node not joining the cluster
+
+### Symptoms
+
+A NodeClaim exists and shows `Launched` but never transitions to `Registered`.
+No corresponding Node appears in `kubectl get nodes`.
+
+### Diagnosis
+
+```bash
+# Check NodeClaim status
+kubectl describe nodeclaim <name>
+
+# Look for the EC2 instance
+aws ec2 describe-instances --filters "Name=tag:karpenter.sh/nodeclaim,Values=<name>" --query 'Reservations[].Instances[].{ID:InstanceId,State:State.Name}'
+
+# Check CloudTrail for IAM errors
+aws cloudtrail lookup-events --lookup-attributes AttributeKey=EventName,AttributeValue=RunInstances --max-results 5
+```
+
+### Common causes
+
+1. **IAM role issues** -- the node role is missing required managed policies
+   (`AmazonEKSWorkerNodeMinimalPolicy`, `AmazonEKSAutoNodePolicy`). Check CloudTrail
+   for `AccessDenied` or `UnauthorizedOperation` on RunInstances.
+
+2. **Security group blocks kubelet** -- the node security group must allow egress to
+   the EKS API server endpoint (port 443). In private clusters, VPC endpoints are
+   required.
+
+3. **Subnet has no available IPs** -- the subnet selected by the NodeClass is
+   exhausted. Check `aws ec2 describe-subnets` for available IP count.
+
+4. **Instance launch failed** -- InsufficientInstanceCapacity in the selected AZ.
+   Karpenter retries with other instance types/AZs if the NodePool allows diversity.
+
+### Fix
+
+For IAM issues, verify the node role in the EKS console under "Access" tab. The
+module in this repo configures IAM correctly by default; if you modified roles
+manually, compare against the module's output.
+
+## Tags not landing on resources
+
+### Symptoms
+
+EC2 instances, EBS volumes, or ALBs appear without your custom tags. CloudTrail may
+show `UnauthorizedOperation` errors.
+
+### Diagnosis
+
+```bash
+# Check CloudTrail for tag-related denials
+aws cloudtrail lookup-events --lookup-attributes AttributeKey=EventName,AttributeValue=RunInstances --query 'Events[?contains(CloudTrailEvent, `UnauthorizedOperation`)].CloudTrailEvent' --max-results 3
+
+# Verify IAM policy exists on cluster role
+aws iam list-attached-role-policies --role-name <cluster-node-role-name>
+```
+
+### 5 common reasons
+
+1. **Missing IAM custom-tags policy** -- the managed policies only allow `eks:*`,
+   `kubernetes.io/*`, and `karpenter.sh/*` tag keys. Custom keys require
+   `enable_auto_mode_custom_tags=true` in the EKS module (this repo sets it by default).
+
+2. **Editing the managed `default` NodeClass** -- adding `spec.tags` to the default
+   NodeClass reverts silently. Create a custom NodeClass instead.
+
+3. **StorageClass parameters are immutable** -- changing `tagSpecification` on an
+   existing StorageClass requires delete + recreate. `kubectl apply` on changed
+   params silently fails or errors.
+
+4. **Tags only apply to future resources** -- existing EC2/EBS/ALB resources keep
+   their original tags. Retag imperatively with `aws ec2 create-tags` or
+   `aws elbv2 add-tags`.
+
+5. **NodePool doesn't reference the custom NodeClass** -- if `nodeClassRef.name`
+   still points to `default`, your custom NodeClass tags are ignored.
+
+### Fix
+
+Verify `enable_auto_mode_custom_tags=true` in `terraform/eks.tf`, ensure your
+NodePool references the correct custom NodeClass, and run `terraform apply` to
+reconcile. See `claude-md/TAGGING.md` for the full 5-layer tagging guide.
+
+## Load balancer not provisioning
+
+### Symptoms
+
+Ingress or Service of type LoadBalancer stays without an ADDRESS. Events show
+errors about subnet discovery or permissions.
+
+### Diagnosis
+
+```bash
+# Check Ingress events
+kubectl describe ingress <name> -n <ns>
+
+# Check Service events (for NLB)
+kubectl describe svc <name> -n <ns>
+
+# Verify subnet tags
+aws ec2 describe-subnets --filters "Name=vpc-id,Values=<vpc-id>" --query 'Subnets[].[SubnetId,Tags[?Key==`kubernetes.io/role/elb`]]'
+```
+
+### Common causes
+
+1. **Missing subnet tags** -- ALB controller discovers subnets by tags:
+   - Public subnets: `kubernetes.io/role/elb: "1"`
+   - Private subnets: `kubernetes.io/role/internal-elb: "1"`
+   
+   This repo adds these automatically. Custom VPCs must add them manually.
+
+2. **IngressClass not found** -- the Ingress must specify
+   `spec.ingressClassName: alb` (or use the `kubernetes.io/ingress.class` annotation).
+
+3. **NLB missing loadBalancerClass** -- for Auto Mode NLBs, the Service must set
+   `spec.loadBalancerClass: eks.amazonaws.com/nlb`.
+
+4. **IngressClassParams misconfigured** -- if you created custom IngressClassParams,
+   verify the scheme (internet-facing vs internal) and subnet selection.
+
+5. **Security group limits** -- VPC has a default limit of 2500 security group rules.
+   Many ALBs + many target groups can exhaust this.
+
+### Fix
+
+For this repo specifically, ensure you ran `terraform apply` successfully (it
+creates IngressClass + IngressClassParams). If using `base_domain`, the ALB scheme
+switches to internet-facing automatically.
+
+## Storage class issues
+
+### Symptoms
+
+PVCs stay `Pending`. Events reference the wrong provisioner or show binding errors.
+
+### Diagnosis
+
+```bash
+# Check PVC events
+kubectl describe pvc <name> -n <ns>
+
+# Verify StorageClass provisioner
+kubectl get sc -o custom-columns='NAME:.metadata.name,PROVISIONER:.provisioner'
+```
+
+### Common causes
+
+1. **Wrong provisioner name** -- Auto Mode uses `ebs.csi.eks.amazonaws.com`, NOT
+   `ebs.csi.aws.com`. The latter is the self-managed driver. If your StorageClass
+   references the wrong provisioner, PVCs will never bind.
+
+2. **Volume type not supported** -- Auto Mode EBS supports gp3, gp2, io1, io2, st1,
+   sc1. Verify your StorageClass `parameters.type`.
+
+3. **AZ mismatch** -- EBS volumes are AZ-local. If the pod is constrained to AZ-a
+   but the PV was created in AZ-b, it cannot attach. Use
+   `volumeBindingMode: WaitForFirstConsumer` (this repo sets it by default).
+
+4. **KMS key permissions** -- if using encrypted volumes with a customer-managed key,
+   the node role must have `kms:CreateGrant` and `kms:Decrypt` on that key.
+
+### Fix
+
+Check `kubectl get sc ebs-csi -o yaml` and confirm:
+```yaml
+provisioner: ebs.csi.eks.amazonaws.com
+volumeBindingMode: WaitForFirstConsumer
+```
+
+## SELinux volume sharing
+
+### Symptoms
+
+Multiple pods mounting the same PVC get permission denied errors, or one pod succeeds
+and another fails with `Operation not permitted` on the mounted path.
+
+### Cause
+
+Auto Mode nodes run Bottlerocket with SELinux enabled. When two pods mount the same
+volume, they must share the same SELinux context. If they have different (or no)
+`seLinuxOptions.level`, the kernel blocks cross-context access.
+
+### Fix
+
+Set matching `seLinuxOptions.level` in both pod security contexts:
+
+```yaml
+spec:
+  securityContext:
+    seLinuxOptions:
+      level: "s0:c123,c456"   # Same value in all pods sharing the volume
+```
+
+Or use `seLinuxChangePolicy: Recursive` (K8s 1.27+) if only one pod mounts at a time
+and you want relabeling on attach.
+
+## Off-cluster controller issues
+
+### Symptoms
+
+Managed components (Karpenter, ALB controller, EBS CSI) behave unexpectedly:
+- Nodes not consolidating despite underutilization
+- ALBs not updating target groups
+- Volumes not detaching after pod deletion
+
+### Diagnosis
+
+These components run in the AWS control plane. You cannot view their logs directly.
+
+```bash
+# Check NodePool status conditions
+kubectl get nodepool <name> -o jsonpath='{.status.conditions}'
+
+# Check for NodeClaim status
+kubectl get nodeclaims -o wide
+
+# Look for EKS platform events in CloudTrail
+aws cloudtrail lookup-events --lookup-attributes AttributeKey=EventSource,AttributeValue=eks.amazonaws.com --max-results 10
+```
+
+### Fix
+
+If a managed component is misbehaving and you have verified your manifests are
+correct, open an AWS Support ticket. Include:
+- Cluster name and region
+- Timestamp of the issue
+- Relevant resource names (NodePool, NodeClaim, Ingress, PVC)
+- Expected vs actual behavior
+
+AWS Support can access the control-plane component logs that you cannot see.
+
+## CloudWatch Logs Insights query for Karpenter events
+
+Auto Mode emits Kubernetes events from Karpenter into the cluster event stream.
+Query them with:
+
+```bash
+# Recent Karpenter-related events
+kubectl get events --field-selector reason!=Scheduled,reason!=Pulling,reason!=Pulled,reason!=Created,reason!=Started -A | grep -i 'karpenter\|nodepool\|nodeclaim\|consolidat'
+
+# If Container Insights is enabled, query CloudWatch
+aws logs start-query --log-group-name "/aws/containerinsights/<cluster-name>/performance" --start-time $(date -d '1 hour ago' +%s) --end-time $(date +%s) --query-string 'fields @timestamp, @message | filter @message like /karpenter/ | sort @timestamp desc | limit 50'
+```
+
+For broader event history (events expire from etcd after 1 hour):
+
+```bash
+# CloudWatch Logs Insights (if observability enabled)
+# Log group: /aws/eks/<cluster-name>/cluster
+# Query:
+fields @timestamp, @message
+| filter @logStream like /kube-apiserver-audit/
+| filter @message like /nodeclaims|nodepools/
+| sort @timestamp desc
+| limit 100
+```
+
+## NodeDiagnostic resource for node logs
+
+When you need logs from a specific node (kubelet, containerd, kernel), use the
+NodeDiagnostic custom resource:
+
+```yaml
+apiVersion: eks.amazonaws.com/v1
+kind: NodeDiagnostic
+metadata:
+  name: <node-name>    # Must match the Node name exactly
+```
+
+```bash
+# Create the diagnostic
+kubectl apply -f - <<EOF
+apiVersion: eks.amazonaws.com/v1
+kind: NodeDiagnostic
+metadata:
+  name: $(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+EOF
+
+# Check status (contains S3 presigned URL for log bundle)
+kubectl get nodediagnostic <node-name> -o yaml
+```
+
+The status includes a presigned S3 URL where you can download the log bundle.
+NodeDiagnostic resources auto-delete after 30 minutes.
+
+This replaces SSH/SSM for node-level debugging on Auto Mode.
+
+## Sources
+
+- [Troubleshooting Auto Mode](https://docs.aws.amazon.com/eks/latest/userguide/auto-troubleshoot.html)
+- [Get node logs (NodeDiagnostic)](https://docs.aws.amazon.com/eks/latest/userguide/auto-get-logs.html)
+- [Auto Mode IAM](https://docs.aws.amazon.com/eks/latest/userguide/auto-learn-iam.html)
+- [Tag subnets for Auto Mode](https://docs.aws.amazon.com/eks/latest/userguide/tag-subnets-auto.html)
+- [Configure ALB](https://docs.aws.amazon.com/eks/latest/userguide/auto-configure-alb.html)
+- [Configure NLB](https://docs.aws.amazon.com/eks/latest/userguide/auto-configure-nlb.html)
+- [Create StorageClass](https://docs.aws.amazon.com/eks/latest/userguide/create-storage-class.html)
+- [Auto Mode reference](https://docs.aws.amazon.com/eks/latest/userguide/auto-reference.html)
+- [Best practices for Auto Mode](https://docs.aws.amazon.com/eks/latest/best-practices/automode.html)
+- [This repository](https://github.com/aws-samples/sample-aws-eks-auto-mode)


### PR DESCRIPTION
## Summary

- Adds `skills/eks-automode-onboard/` — newcomer skill covering Auto Mode concepts, deployment walkthrough, example selection decision tree, and first-encounter troubleshooting
- Adds `skills/eks-automode-maintain/` — maintainer skill covering the templatefile() rendering chain, 5-layer tagging consistency verification, docs-sync decision matrix, and PR checklist
- Both follow the [skill-creator framework](https://github.com/anthropics/skills/tree/main/skills/skill-creator): YAML frontmatter with trigger phrases, body under 500 lines, overflow into `references/`
- Every file includes a Sources section with links to relevant AWS docs and repo URLs

## Structure

```
skills/
├── eks-automode-onboard/
│   ├── SKILL.md (208 lines)
│   └── references/
│       ├── concepts.md
│       ├── deployment-guide.md
│       └── troubleshooting.md
└── eks-automode-maintain/
    ├── SKILL.md (175 lines)
    └── references/
        ├── file-relationships.md
        ├── tagging-consistency.md
        └── docs-sync-checklist.md
```

## Test plan

- [ ] Verify SKILL.md frontmatter parses correctly (valid YAML between `---` fences)
- [ ] Confirm all external links in Sources sections resolve (no 404s)
- [ ] Spot-check that concepts.md facts match current AWS docs
- [ ] Validate trigger phrases in description field match intended use cases