### PR TITLE
feat(plugin): add Claude Code plugin marketplace for skill distribution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,25 @@
+{
+  "name": "sample-aws-eks-auto-mode",
+  "description": "EKS Auto Mode skills for Claude Code - onboarding and maintenance",
+  "version": "1.0.0",
+  "owner": {
+    "name": "AWS Samples"
+  },
+  "plugins": [
+    {
+      "name": "eks-automode",
+      "source": "./",
+      "description": "Two Claude Code skills for EKS Auto Mode: onboarding guide for newcomers and maintenance playbook for repo maintainers",
+      "version": "1.0.0",
+      "author": {
+        "name": "AWS Samples"
+      },
+      "displayName": "EKS Auto Mode Skills",
+      "homepage": "https://github.com/aws-samples/sample-aws-eks-auto-mode",
+      "repository": "https://github.com/aws-samples/sample-aws-eks-auto-mode",
+      "license": "MIT-0",
+      "keywords": ["eks", "auto-mode", "kubernetes", "aws"],
+      "category": "cloud"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "eks-automode",
+  "displayName": "EKS Auto Mode Skills",
+  "version": "1.0.0",
+  "description": "Two Claude Code skills for EKS Auto Mode: onboarding guide for newcomers and maintenance playbook for repo maintainers",
+  "author": {
+    "name": "AWS Samples",
+    "url": "https://github.com/aws-samples"
+  },
+  "homepage": "https://github.com/aws-samples/sample-aws-eks-auto-mode",
+  "repository": "https://github.com/aws-samples/sample-aws-eks-auto-mode",
+  "license": "MIT-0",
+  "keywords": ["eks", "auto-mode", "kubernetes", "aws", "karpenter", "nodepool", "nodeclass"]
+}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - [Cleanup](#cleanup)
 - [Configuration](#configuration)
 - [Components](#components)
+- [Claude Code Skills](#claude-code-skills-plugin)
 - [Learn More](#learn-more)
 - [Contributing](#contributing)
 - [License and Disclaimer](#license-and-disclaimer)
@@ -253,6 +254,36 @@ EKS Auto Mode includes the EBS CSI driver as a managed component. No installatio
 - Custom KMS encryption may require additional IAM permissions.
 
 [AWS Documentation](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html)
+
+## Claude Code Skills (Plugin)
+
+This repo ships as a Claude Code plugin with two skills for EKS Auto Mode:
+
+| Skill | Audience | What it covers |
+|-------|----------|----------------|
+| `eks-automode-onboard` | Newcomers | Concepts, deployment, example selection, troubleshooting |
+| `eks-automode-maintain` | Repo maintainers | Rendering chain, 5-layer tagging, docs sync, PR checklist |
+
+### Install via plugin marketplace
+
+```bash
+/plugin marketplace add aws-samples/sample-aws-eks-auto-mode
+/plugin install eks-automode@sample-aws-eks-auto-mode
+```
+
+### Alternative: manual install
+
+```bash
+git clone https://github.com/aws-samples/sample-aws-eks-auto-mode.git
+cp -r sample-aws-eks-auto-mode/skills/eks-automode-onboard ~/.claude/skills/
+cp -r sample-aws-eks-auto-mode/skills/eks-automode-maintain ~/.claude/skills/
+```
+
+### Local testing (from repo root)
+
+```bash
+claude --plugin-dir .
+```
 
 ## Learn More
 

--- a/misc/website/docs/skills/index.md
+++ b/misc/website/docs/skills/index.md
@@ -1,0 +1,71 @@
+---
+sidebar_position: 5
+title: Claude Code Skills
+description: "Install EKS Auto Mode skills for Claude Code. Plugin marketplace setup, manual install, and local testing for onboarding and maintenance workflows."
+keywords: [claude code, skills, plugin, eks auto mode, AI assistant, developer tools]
+---
+
+# Claude Code Skills
+
+This repository ships as a [Claude Code](https://claude.ai/code) plugin with two skills for EKS Auto Mode.
+
+| Skill | Audience | What it covers |
+|-------|----------|----------------|
+| [eks-automode-onboard](./onboard) | Newcomers | Concepts, deployment, example selection, troubleshooting |
+| [eks-automode-maintain](./maintain) | Repo maintainers | Rendering chain, 5-layer tagging, docs sync, PR checklist |
+
+## Install via plugin marketplace
+
+The fastest path. Run these two commands inside Claude Code:
+
+```bash
+/plugin marketplace add aws-samples/sample-aws-eks-auto-mode
+/plugin install eks-automode@sample-aws-eks-auto-mode
+```
+
+Both skills become available immediately as `/eks-automode:eks-automode-onboard` and `/eks-automode:eks-automode-maintain`.
+
+## Alternative: manual install
+
+Clone and copy the skill directories into your personal skills folder:
+
+```bash
+git clone https://github.com/aws-samples/sample-aws-eks-auto-mode.git
+cp -r sample-aws-eks-auto-mode/skills/eks-automode-onboard ~/.claude/skills/
+cp -r sample-aws-eks-auto-mode/skills/eks-automode-maintain ~/.claude/skills/
+```
+
+## Local testing (from repo root)
+
+Load the plugin directly without installing:
+
+```bash
+claude --plugin-dir .
+```
+
+## What the skills do
+
+### eks-automode-onboard
+
+Helps you go from zero to a running EKS Auto Mode cluster. Covers:
+
+- What Auto Mode manages vs what you manage
+- Which example to deploy for your use case
+- Step-by-step deployment walkthrough
+- Common first-day issues and how to fix them
+
+### eks-automode-maintain
+
+Helps you keep this repo's code and docs in sync. Covers:
+
+- The `templatefile()` rendering chain (why `.tpl` edits need `terraform apply`)
+- 5-layer tagging consistency verification
+- Decision matrix: "I changed X, what else needs updating?"
+- PR checklist for maintainers
+
+## Sources
+
+- [Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code)
+- [Claude Code plugin system](https://github.com/anthropics/skills/tree/main/skills/skill-creator)
+- [EKS Auto Mode documentation](https://docs.aws.amazon.com/eks/latest/userguide/automode.html)
+- [This repository](https://github.com/aws-samples/sample-aws-eks-auto-mode)

--- a/misc/website/docs/skills/maintain.md
+++ b/misc/website/docs/skills/maintain.md
@@ -1,0 +1,82 @@
+---
+sidebar_position: 2
+title: "Skill: eks-automode-maintain"
+description: "EKS Auto Mode repo maintenance skill for Claude Code. Covers the rendering chain, 5-layer tagging, docs sync, and PR checklist for maintainers."
+keywords: [eks auto mode, maintenance, tagging, templatefile, docs sync, claude code skill, PR checklist]
+---
+
+# eks-automode-maintain
+
+A Claude Code skill for maintainers of this repository who need to keep code, templates, and documentation in sync.
+
+## When to use
+
+Trigger this skill when you:
+
+- Changed a `.tpl` file and need to know what else to update
+- Want to verify 5-layer tagging consistency
+- Are preparing a PR and need the checklist
+- Need to update TAGGING.md or CLEANUP.md
+- Want to understand the file dependency graph
+
+## What it covers
+
+### The rendering chain
+
+```
+nodepool-templates/*.yaml.tpl   (source of truth)
+         |
+         v  terraform apply (templatefile + local_file)
+         |
+nodepools/*.yaml                (rendered output)
+```
+
+Key gotcha: editing a `.tpl` does NOT reach the cluster until `terraform apply` re-renders. `kubectl apply` of stale rendered YAML silently reverts the fix.
+
+### Decision matrix
+
+| Changed | Also update |
+|---------|-------------|
+| `nodepool-templates/*.yaml.tpl` | `terraform apply` to re-render; verify `nodepools/` |
+| `terraform/variables.tf` (new var) | `setup.tf` (pass to templatefile); README variable table |
+| `terraform/eks.tf` | `claude-md/TAGGING.md` if tag-related; README if feature-facing |
+| `examples/*` (new example) | README examples table; docs site sidebar; `setup.tf` if `.tpl` |
+| `terraform/tagging.tf` | `claude-md/TAGGING.md`; verify 5-layer coverage |
+| `scripts/cleanup.sh` | `claude-md/CLEANUP.md` flags/usage section |
+| `terraform/versions.tf` | README prerequisites (provider versions) |
+| `terraform/ingressclass.tf` | `claude-md/TAGGING.md` Layer 5 section |
+
+### 5-layer tagging verification
+
+| Layer | File | Tags |
+|-------|------|------|
+| 1. Provider `default_tags` | `terraform/main.tf` | All TF-direct resources |
+| 2. `cluster_tags` | `terraform/eks.tf` | EKS primary security group |
+| 3. NodeClass `spec.tags` | `nodepool-templates/*.yaml.tpl` | EC2, root EBS, ENIs |
+| 4. StorageClass `tagSpecification` | `terraform/tagging.tf` | PVC-provisioned EBS |
+| 5. IngressClassParams `spec.tags` | `terraform/ingressclass.tf` | ALBs, target groups |
+
+### PR checklist
+
+- [ ] Every `.tpl` change validated via `terraform apply`
+- [ ] New variables in README Configuration section
+- [ ] Tag changes reflected in `claude-md/TAGGING.md`
+- [ ] Cleanup changes reflected in `claude-md/CLEANUP.md`
+- [ ] New examples have README with prereqs and commands
+- [ ] Rendered YAML paths in `.gitignore` if generated
+- [ ] No hardcoded cluster names or account IDs
+- [ ] Example READMEs use relative paths
+
+### Reference docs (loaded on demand)
+
+- `references/file-relationships.md` -- complete file map and dependency graph
+- `references/tagging-consistency.md` -- full 5-layer verification with debug commands
+- `references/docs-sync-checklist.md` -- when to update each doc file, PR template
+
+## Sources
+
+- [Tag propagation IAM policy](https://docs.aws.amazon.com/eks/latest/userguide/auto-cluster-iam-role.html#tag-prop)
+- [Custom NodeClass creation](https://docs.aws.amazon.com/eks/latest/userguide/create-node-class.html)
+- [EKS Auto Mode best practices](https://docs.aws.amazon.com/eks/latest/best-practices/automode.html)
+- [This repository](https://github.com/aws-samples/sample-aws-eks-auto-mode)
+- Internal: `claude-md/TAGGING.md`, `claude-md/CLEANUP.md`

--- a/misc/website/docs/skills/onboard.md
+++ b/misc/website/docs/skills/onboard.md
@@ -1,0 +1,71 @@
+---
+sidebar_position: 1
+title: "Skill: eks-automode-onboard"
+description: "EKS Auto Mode onboarding skill for Claude Code. Covers concepts, deployment, example selection, and troubleshooting for newcomers to Auto Mode."
+keywords: [eks auto mode, onboarding, getting started, claude code skill, deployment guide, troubleshooting]
+---
+
+# eks-automode-onboard
+
+A Claude Code skill for users new to EKS Auto Mode who want to understand concepts and deploy using this repository.
+
+## When to use
+
+Trigger this skill when you:
+
+- Want to understand what EKS Auto Mode manages
+- Need to deploy your first Auto Mode cluster
+- Are choosing which example fits your use case
+- Hit a common first-day issue (Pending pods, tags not landing, LB not provisioning)
+
+## What it covers
+
+### Quick decision tree
+
+Maps your use case to the right example directory:
+
+| Use case | Example |
+|----------|---------|
+| First deployment / validation | `examples/graviton/` |
+| Fault-tolerant batch / dev | `examples/spot/` |
+| ML inference (NVIDIA GPU) | `examples/gpu/` |
+| ML inference (Inferentia2) | `examples/neuron/` |
+| OD + Spot mix with headroom | `examples/cost-optimization/` |
+| Pin to reserved capacity | `examples/capacity-reservation/` |
+| Fixed always-on fleet | `examples/static-capacity/` |
+| Protect long-running jobs | `examples/batch-jobs/` |
+| Limit drain concurrency | `examples/disruption-budgets/` |
+| CPU autoscaling + SQS-driven | `examples/pod-autoscaling/` |
+| Metrics, logs, tracing | `examples/observability/` |
+
+### Key concepts
+
+- What AWS manages vs what you manage (shared responsibility)
+- NodePool and NodeClass relationship
+- The `templatefile()` rendering chain
+- Why you never edit the managed `default` NodeClass
+
+### Common gotchas
+
+1. Pods stuck Pending -- nodeSelector mismatch
+2. Wrong EBS StorageClass provisioner name (`ebs.csi.eks.amazonaws.com`, not `ebs.csi.aws.com`)
+3. Editing default NodeClass -- reverts silently
+4. Tags not landing -- missing IAM custom-tags policy
+5. No SSH/SSM access -- use `kubectl debug node/` or NodeDiagnostic
+6. Stale rendered YAML after template edit -- run `terraform apply`
+7. LB not provisioning -- missing subnet tags
+
+### Reference docs (loaded on demand)
+
+- `references/concepts.md` -- deep dive on managed components, instance families, IMDS, disruption model
+- `references/deployment-guide.md` -- prerequisites, variable reference, post-deploy validation, cleanup
+- `references/troubleshooting.md` -- 8 problem categories with solutions
+
+## Sources
+
+- [EKS Auto Mode overview](https://docs.aws.amazon.com/eks/latest/userguide/automode.html)
+- [Auto Mode best practices](https://docs.aws.amazon.com/eks/latest/best-practices/automode.html)
+- [Create a NodePool](https://docs.aws.amazon.com/eks/latest/userguide/create-node-pool.html)
+- [Create a NodeClass](https://docs.aws.amazon.com/eks/latest/userguide/create-node-class.html)
+- [Troubleshooting Auto Mode](https://docs.aws.amazon.com/eks/latest/userguide/auto-troubleshoot.html)
+- [This repository](https://github.com/aws-samples/sample-aws-eks-auto-mode)


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/plugin.json` manifest so the repo is a valid Claude Code plugin
- Adds `.claude-plugin/marketplace.json` so users can add this repo as a self-hosted marketplace
- Adds "Claude Code Skills" section to README with install instructions (marketplace, manual, local)
- Adds 3 docs site pages under `misc/website/docs/skills/` (index, onboard, maintain)

## Install flow for users

```bash
/plugin marketplace add aws-samples/sample-aws-eks-auto-mode
/plugin install eks-automode@sample-aws-eks-auto-mode
```

## Test plan

- [ ] Verify `claude --plugin-dir .` loads both skills from repo root
- [ ] Confirm marketplace.json source `"./"` resolves correctly
- [ ] Check docs site builds with new skills/ pages (`cd misc/website && npm run build`)
- [ ] Validate all Sources links in docs pages resolve (no 404s)