### PR TITLE
fix(skills): use quoted string for SKILL.md description frontmatter

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "sample-aws-eks-auto-mode",
   "description": "EKS Auto Mode skills for Claude Code - onboarding and maintenance",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "owner": {
     "name": "AWS Samples"
   },
@@ -10,7 +10,7 @@
       "name": "eks-automode",
       "source": "./",
       "description": "Two Claude Code skills for EKS Auto Mode: onboarding guide for newcomers and maintenance playbook for repo maintainers",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "AWS Samples"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "eks-automode",
   "displayName": "EKS Auto Mode Skills",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Two Claude Code skills for EKS Auto Mode: onboarding guide for newcomers and maintenance playbook for repo maintainers",
   "author": {
     "name": "AWS Samples",

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ This repo ships as a [Claude Code](https://claude.ai/code) plugin with two AI-as
 
 ```bash
 /plugin marketplace add https://github.com/aws-samples/sample-aws-eks-auto-mode.git
+```
+
+```bash
 /plugin install eks-automode@sample-aws-eks-auto-mode
 ```
 

--- a/misc/website/docs/skills/index.md
+++ b/misc/website/docs/skills/index.md
@@ -20,6 +20,9 @@ The fastest path. Run these two commands inside Claude Code:
 
 ```bash
 /plugin marketplace add https://github.com/aws-samples/sample-aws-eks-auto-mode.git
+```
+
+```bash
 /plugin install eks-automode@sample-aws-eks-auto-mode
 ```
 

--- a/skills/eks-automode-maintain/SKILL.md
+++ b/skills/eks-automode-maintain/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: eks-automode-maintain
-description: >
-  Repo maintenance for sample-aws-eks-auto-mode — keeping docs, templates,
-  rendered YAML, and tagging layers in sync. Use this skill when updating
-  nodepool templates, terraform config, examples, tagging, cleanup scripts,
-  or any docs in this repo. Triggers on: maintain, docs sync, tagging update,
-  template change, rendered yaml, file relationships, PR checklist, keep in sync.
+description: "Repo maintenance for sample-aws-eks-auto-mode. Keeps docs, templates, rendered YAML, and tagging layers in sync. Use when updating nodepool templates, terraform config, examples, tagging, cleanup scripts, or docs. Triggers: maintain, docs sync, tagging update, template change, rendered yaml, file relationships, PR checklist, keep in sync."
 ---
 
 # EKS Auto Mode — Maintainer Skill

--- a/skills/eks-automode-onboard/SKILL.md
+++ b/skills/eks-automode-onboard/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: eks-automode-onboard
-description: >
-  Onboarding guide for EKS Auto Mode newcomers. Use this skill when the user asks
-  about EKS Auto Mode concepts, wants to deploy their first Auto Mode cluster using
-  this repo, needs help picking an example, or hits common first-day issues. Trigger
-  phrases: "what is Auto Mode", "how do I deploy", "which example should I use",
-  "getting started with EKS Auto Mode", "first cluster", "deploy this repo",
-  "Auto Mode tutorial", "newbie", "onboard", "walkthrough".
+description: "Onboarding guide for EKS Auto Mode newcomers. Use when the user asks about EKS Auto Mode concepts, wants to deploy their first Auto Mode cluster, needs help picking an example, or hits common first-day issues. Triggers: what is Auto Mode, how do I deploy, which example, getting started, first cluster, deploy this repo, Auto Mode tutorial, onboard, walkthrough."
 ---
 
 # EKS Auto Mode Onboarding


### PR DESCRIPTION
## Summary

- Converts SKILL.md `description` from YAML folded scalar (`>`) to a simple quoted string
- Fixes skill discovery issue where `/reload-plugins` showed "0 skills" despite correct directory structure
- Verified working with `claude --plugin-dir .` after this change

## Test plan

- [ ] Uninstall existing plugin: `/plugin uninstall eks-automode@sample-aws-eks-auto-mode`
- [ ] Reinstall: `/plugin install eks-automode@sample-aws-eks-auto-mode`
- [ ] `/reload-plugins` should show "2 skills"