### PR TITLE
fix(terraform): defer kubectl provider with lazy_load for fresh single-apply

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -61,7 +61,16 @@ locals {
 }
 
 provider "kubectl" {
-  apply_retry_count      = 5
+  apply_retry_count = 5
+  # lazy_load defers building the Kubernetes client until a kubectl_manifest
+  # resource is actually applied, rather than at provider-configure time.
+  # Required for a single-pass `terraform apply` on a fresh account: the EKS
+  # cluster is created in the same run, so host/CA are unknown at plan time.
+  # alekc/kubectl >= 2.3.0 configures eagerly by default and otherwise fails
+  # with "invalid provider configuration: no configuration has been provided"
+  # (see alekc/terraform-provider-kubectl#283). The helm/kubernetes providers
+  # already defer this, which is why they don't hit the same error.
+  lazy_load              = true
   host                   = module.eks.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
   load_config_file       = false


### PR DESCRIPTION
## Problem

A first-time `terraform apply` on a fresh account fails almost immediately (before creating any resources) with:

```
Error: invalid provider configuration: invalid configuration: no configuration
has been provided, try setting KUBERNETES_MASTER environment variable

  with provider["registry.terraform.io/alekc/kubectl"],
  on main.tf line 63, in provider "kubectl":
  63: provider "kubectl" {
```

`terraform plan` succeeds; only `apply` fails.

## Root cause

`alekc/kubectl` **v2.3.0** changed the provider to build its Kubernetes client **eagerly at provider-configure time** instead of deferring to first use. This repo configures the provider with `host = module.eks.cluster_endpoint`, and the EKS cluster is created **in the same apply**, so the endpoint/CA are unknown until apply time. Eager configuration against an unknown host throws the error above.

The `helm` and `hashicorp/kubernetes` providers already defer client construction, which is why they don't fail with the same `module.eks.*` references. The repo's `~> 2.1` constraint floats `alekc/kubectl` up to the affected 2.4.x line.

Upstream tracking issue: [alekc/terraform-provider-kubectl#283](https://github.com/alekc/terraform-provider-kubectl/issues/283).

## Fix

Set `lazy_load = true` on the `kubectl` provider block. This restores deferred client construction (opt-in flag added in alekc/kubectl v2.4.0), so the cluster and its `kubectl_manifest` resources (StorageClass, IngressClass/params) apply in a single pass — no two-stage `-target` apply required. Keeps the repo on the latest provider.

## Testing

Verified **end-to-end with a real fresh deploy** (EKS Auto Mode, `us-east-1`, EKS module `~> 20.24`, Terraform 1.12.2, `alekc/kubectl` 2.4.1):

- **Before:** `terraform apply` fails at provider-config in ~1 min; state empty.
- **After (`lazy_load = true`):** `Apply complete! Resources: 74 added, 0 changed, 0 destroyed` — all `kubectl_manifest` resources created against the live cluster.
- Also confirmed pinning `alekc/kubectl <= 2.2.0` resolves it (deferred by default), but `lazy_load` keeps us current.
- `terraform fmt` and `terraform validate` pass.